### PR TITLE
Remove disabling of optimization for exception handlers

### DIFF
--- a/sope-appserver/NGObjWeb/DynamicElements/GNUmakefile.preamble
+++ b/sope-appserver/NGObjWeb/DynamicElements/GNUmakefile.preamble
@@ -5,12 +5,6 @@ ADDITIONAL_CPPFLAGS += -pipe
 # -DPROFILE_CLUSTERS=1
 
 
-# disable optimization for exception handlers
-SaxDefaultHandler.m_FILE_FILTER_OUT_FLAGS = -O%
-WOCompoundElement.m_FILE_FILTER_OUT_FLAGS = -O%
-WOImage.m_FILE_FILTER_OUT_FLAGS           = -O%
-
-
 ADDITIONAL_CPPFLAGS += -pipe -Wall -funsigned-char -O2
 ADDITIONAL_CPPFLAGS += -DCOMPILING_NGOBJWEB=1
 

--- a/sope-xml/DOM/GNUmakefile.preamble
+++ b/sope-xml/DOM/GNUmakefile.preamble
@@ -16,13 +16,6 @@ DOM_HEADER_FILES = $(libDOM_HEADER_FILES)
 DOM_OBJC_FILES   = $(libDOM_OBJC_FILES)
 
 
-# disable optimization for exception handlers
-DOMPYXOutputter.m_FILE_FILTER_OUT_FLAGS        = -O%
-DOMXMLOutputter.m_FILE_FILTER_OUT_FLAGS        = -O%
-DOMQueryPathExpression.m_FILE_FILTER_OUT_FLAGS = -O%
-DOMSaxHandler.m_FILE_FILTER_OUT_FLAGS          = -O%
-NSObject+QPEval.m_FILE_FILTER_OUT_FLAGS        = -O%
-
 ADDITIONAL_CPPFLAGS += \
 	-O2 \
         -Wall -DCOMPILE_FOR_GSTEP_MAKE=1        \

--- a/sope-xml/SaxObjC/GNUmakefile.preamble
+++ b/sope-xml/SaxObjC/GNUmakefile.preamble
@@ -16,11 +16,6 @@ libSaxObjC_HEADER_FILES_INSTALL_DIR = /SaxObjC
 SaxObjC_HEADER_FILES = $(libSaxObjC_HEADER_FILES)
 SaxObjC_OBJC_FILES   = $(libSaxObjC_OBJC_FILES)
 
-# disable optimization for exception handlers
-SaxDefaultHandler.m_FILE_FILTER_OUT_FLAGS = -O%
-SaxHandlerBase.m_FILE_FILTER_OUT_FLAGS    = -O%
-SaxObjectDecoder.m_FILE_FILTER_OUT_FLAGS  = -O%
-
 ADDITIONAL_CPPFLAGS += \
 	-O2 \
         -Wall -DCOMPILE_FOR_GSTEP_MAKE=1        \

--- a/sope-xml/XmlRpc/GNUmakefile.preamble
+++ b/sope-xml/XmlRpc/GNUmakefile.preamble
@@ -11,9 +11,6 @@ XmlRpc_INTERFACE_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION)
 XmlRpc_VERSION=$(MAJOR_VERSION).$(MINOR_VERSION).$(SUBMINOR_VERSION)
 
 
-# disable optimization for exception handlers
-NSObject+XmlRpc.m_FILE_FILTER_OUT_FLAGS = -O%
-
 ADDITIONAL_CPPFLAGS += \
 	-O2 \
         -Wall -DCOMPILE_FOR_GSTEP_MAKE=1        \


### PR DESCRIPTION
This isn't necessary anymore and if optimization is disabled some of the gcc hardening features are also disabled
