### PR TITLE
Fix crash when decoding a = at end of the data

### DIFF
--- a/sope-core/NGExtensions/NGQuotedPrintableCoding.m
+++ b/sope-core/NGExtensions/NGQuotedPrintableCoding.m
@@ -147,17 +147,21 @@ int NGDecodeQuotedPrintableX(const char *_src, unsigned _srcLen,
       destCnt++;
     }
     else {
-      if ((_srcLen - cnt) > 2) {
+      if ((_srcLen - cnt) > 1) {
         signed char c1, c2;
 
 	cnt++;          // skip '='
         c1 = _src[cnt]; // first hex digit
 	
         if (c1 == '\r' || c1 == '\n') {
-          if (_src[cnt + 1] == '\r' || _src[cnt + 1] == '\n' )
+          if (cnt < _srcLen && (_src[cnt + 1] == '\r' || _src[cnt + 1] == '\n' ))
             cnt++;
           continue;
         }
+
+        if (cnt == _srcLen)  /* We have reached the end of the _src */
+          break;
+
         c1 = __hexToChar(c1);
 	
 	cnt++; // skip first hex digit


### PR DESCRIPTION
In decoding a quoted printable mail. There is a buffer overflow as we are always parsing two bytes instead of one.

See the full backtrace at:

https://gist.github.com/sixstone-qq/cb8099b66c2911e8aaf2

This patch avoid regressions to manage = at the end of the source.
