### PR TITLE
 Fix memory leak when failing to parse a quoted printable 

### DIFF
--- a/sope-core/NGExtensions/NGQuotedPrintableCoding.m
+++ b/sope-core/NGExtensions/NGQuotedPrintableCoding.m
@@ -72,10 +72,17 @@
   resSize = 
     NGDecodeQuotedPrintableX([self bytes], [self length], dest, destSize, YES);
   
-  return ((int)resSize != -1)
-    ? [NSData dataWithBytesNoCopy:dest length:resSize]
-    : nil;
+  if ((int)resSize != -1)
+    {
+      return [NSData dataWithBytesNoCopy:dest length:resSize];
+    }
+  else
+    {
+      free(dest);
+      return nil;
+    }
 }
+
 - (NSData *)dataByDecodingQuotedPrintableTransferEncoding {
   char   *dest;
   size_t destSize;
@@ -87,9 +94,15 @@
   resSize = 
     NGDecodeQuotedPrintableX([self bytes], [self length], dest, destSize, NO);
   
-  return ((int)resSize != -1)
-    ? [NSData dataWithBytesNoCopy:dest length:resSize]
-    : nil;
+  if ((int)resSize != -1)
+    {
+      return [NSData dataWithBytesNoCopy:dest length:resSize];
+    }
+  else
+    {
+      free(dest);
+      return nil;
+    }
 }
 
 - (NSData *)dataByEncodingQuotedPrintable {


### PR DESCRIPTION
One of multiple valgrind reports:

```
604 bytes in 1 blocks are definitely lost in loss record 8,010 of 10,179
  at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
  by 0x2BF73131: _i_NSData_QuotedPrintableCoding_dataByDecodingQuotedPrintableTransferEncoding (in /usr/lib/libNGExtensions.so.4.9.203)
  by 0x3375053E: _i_NSData_SOGoMailUtilities_bodyDataFromEncoding_ (in /usr/lib/GNUstep/SOGo/Mailer.SOGo/Mailer)
  by 0x34D23B46: _i_MAPIStoreMailMessage__setBodyContentFromRawData_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
  by 0x34D1DD0A: _i_MAPIStoreMailFolder__lookupMessage_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
  by 0x34CF4312: _i_MAPIStoreFolder__lookupMessageByURL_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
  by 0x34CF497A: _i_MAPIStoreFolder__openMessage_withMID_forWriting_inMemCtx_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
  by 0x2A5D5013: sogo_folder_open_message (in /usr/lib/x86_64-linux-gnu/mapistore_backends/libMAPIStoreSOGo.so.1.0.0)
```
