### PR TITLE
Fix memory leak when failing to decode/encode a quoted printable

### DIFF
--- a/sope-core/NGExtensions/NGQuotedPrintableCoding.m
+++ b/sope-core/NGExtensions/NGQuotedPrintableCoding.m
@@ -109,13 +109,13 @@
 
   // length/64*3 should be plenty for soft newlines
   desLen = (length + length/64) *3;
-  des = NGMallocAtomic(sizeof(char) * desLen);
+  des = malloc(sizeof(char) * desLen);
 
   desLen = NGEncodeQuotedPrintable(bytes, length, des, desLen);
 
   if ((int)desLen == -1)
     {
-      NGFree(des);
+      free(des);
       return nil;
     }
 


### PR DESCRIPTION
Valgrind report:

   604 bytes in 1 blocks are definitely lost in loss record 8,010 of 10,179
      at 0x4C2AB80: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
      by 0x2BF73131: _i_NSData_QuotedPrintableCoding_dataByDecodingQuotedPrintableTransferEncoding (in /usr/lib/libNGExtensions.so.4.9.203)
      by 0x3375053E: _i_NSData_SOGoMailUtilities_bodyDataFromEncoding_ (in /usr/lib/GNUstep/SOGo/Mailer.SOGo/Mailer)
      by 0x34D23B46: _i_MAPIStoreMailMessage__setBodyContentFromRawData_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
      by 0x34D1DD0A: _i_MAPIStoreMailFolder__lookupMessage_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
      by 0x34CF4312: _i_MAPIStoreFolder__lookupMessageByURL_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
      by 0x34CF497A: _i_MAPIStoreFolder__openMessage_withMID_forWriting_inMemCtx_ (in /usr/lib/GNUstep/SOGo/SOGoBackend.MAPIStore/SOGoBackend)
      by 0x2A5D5013: sogo_folder_open_message (in /usr/lib/x86_64-linux-gnu/mapistore_backends/libMAPIStoreSOGo.so.1.0.0)
- removing trailing whitespaces.
