### PR TITLE
Stage 1 of clang complier warning patches. These are mostly fixes for…

### DIFF
--- a/sope-appserver/NGObjWeb/Associations/WOScriptAssociation.m
+++ b/sope-appserver/NGObjWeb/Associations/WOScriptAssociation.m
@@ -125,7 +125,7 @@ static BOOL doDebug = NO;
       v = [v substringToIndex:9];
       v = [v stringByApplyingCEscaping];
       [str appendString:v];
-      [str appendFormat:@"...[len=%i]", [self->script length]];
+      [str appendFormat:@"...[len=%i]", (int)[self->script length]];
   }
   else {
       v = [v stringByApplyingCEscaping];

--- a/sope-appserver/NGObjWeb/Associations/WOValueAssociation.m
+++ b/sope-appserver/NGObjWeb/Associations/WOValueAssociation.m
@@ -161,7 +161,7 @@ static Class StrClass = Nil;
       v = [v substringToIndex:9];
       v = [v stringByApplyingCEscaping];
       [str appendString:v];
-      [str appendFormat:@"...[len=%i]", [self->value length]];
+      [str appendFormat:@"...[len=%i]", (int)[self->value length]];
     }
     else {
       v = [v stringByApplyingCEscaping];

--- a/sope-appserver/NGObjWeb/DynamicElements/WOGenericElement.m
+++ b/sope-appserver/NGObjWeb/DynamicElements/WOGenericElement.m
@@ -77,10 +77,9 @@ typedef struct {
   [children autorelease];
   
   /* construct self ... */
-  self = [(WODynamicElement *)self initWithName:name 
+  return (WOGenericElement*)[(WODynamicElement *)self initWithName:name 
                                    associations:assocs 
                                    contentElements:children];
-  return self;
 }
 
 - (BOOL)_isASCIIString:(NSString *)_s {

--- a/sope-appserver/NGObjWeb/DynamicElements/WOHyperlink.m
+++ b/sope-appserver/NGObjWeb/DynamicElements/WOHyperlink.m
@@ -75,7 +75,7 @@
     temporaryHyperlink = [_WOTemporaryHyperlink allocWithZone:zone];
   
   if (self == WOHyperlinkClass)
-    return temporaryHyperlink;
+    return (id)temporaryHyperlink;
   else {
 #if PROFILE_CLUSTERS
     static unsigned totalCount        = 0;

--- a/sope-appserver/NGObjWeb/NGHttp/NGHttpResponse.h
+++ b/sope-appserver/NGObjWeb/NGHttp/NGHttpResponse.h
@@ -122,7 +122,7 @@ static inline BOOL NGIsClientErrorHttpStatusCode(NGHttpStatusCode _code) {
   return ((_code >= 400) && (_code < 500)) ? YES : NO;
 }
 static inline BOOL NGIsServerErrorHttpStatusCode(NGHttpStatusCode _code) {
-  return ((_code >= 500) && (_code < 600)) ? YES : NO;
+  return ((_code >= 500) && ((int)_code < 600)) ? YES : NO;
 }
 
 #endif /* __NGHttp_NGHttpResponse_H__ */

--- a/sope-appserver/NGObjWeb/NGHttp/NGUrlFormCoder.m
+++ b/sope-appserver/NGObjWeb/NGHttp/NGUrlFormCoder.m
@@ -93,7 +93,7 @@ static __inline__ NSString *urlStringFromBuffer(const unsigned char *buffer,
                             encoding:NSUTF8StringEncoding];
   if (debugDecoding) {
     NSLog(@"decoded data len %d value (len=%d): %@", 
-	  len, [value length], value);
+	  len, (int)[value length], value);
   }
   return value;
 #if 0
@@ -177,7 +177,7 @@ NGHashMap *NGDecodeUrlFormParameters(const unsigned char *_buffer,
 - (NSString *)stringByApplyingURLEncoding {
   /* NGExtensions/NSString+misc.h */
   NSLog(@"Note: Called deprecated -stringByApplyingURLEncoding method "
-	@"(use -stringByEscapingURL instead)", __PRETTY_FUNCTION__);
+	@"(use -stringByEscapingURL instead)");
   return [self stringByEscapingURL];
 }
 

--- a/sope-appserver/NGObjWeb/SoObjects/SoComponent.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoComponent.m
@@ -59,13 +59,13 @@
 }
 
 - (void)setResourceManager:(WOResourceManager *)_rm {
-  ASSIGN(self->soResourceManager, _rm);
+  ASSIGN(self->soResourceManager, (SoProductResourceManager*)_rm);
 }
 - (WOResourceManager *)resourceManager {
   if (self->soResourceManager != nil)
     return self->soResourceManager;
   
-  self->soResourceManager = [[[self componentProduct] resourceManager] retain];
+  self->soResourceManager = (SoProductResourceManager*)[[[self componentProduct] resourceManager] retain];
   if (self->soResourceManager)
     return self->soResourceManager;
   

--- a/sope-appserver/NGObjWeb/SoObjects/SoDefaultRenderer.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoDefaultRenderer.m
@@ -154,7 +154,7 @@ static int debugOn = 0;
   
   [r setStatus:200];
   [r setHeader:@"application/octet-stream" forKey:@"content-type"];
-  [r setHeader:[NSString stringWithFormat:@"%i", [_data length]] 
+  [r setHeader:[NSString stringWithFormat:@"%i", (int)[_data length]] 
      forKey:@"content-length"];
   [r setContent:_data];
   return nil;

--- a/sope-appserver/NGObjWeb/Templates/WOComponentScriptPart.m
+++ b/sope-appserver/NGObjWeb/Templates/WOComponentScriptPart.m
@@ -112,7 +112,7 @@
       [ms appendFormat:@":%i", self->startLine];
   }
   else if (self->startLine > 0)
-    [ms appendFormat:@" line=%@", self->startLine];
+    [ms appendFormat:@" line=%u", self->startLine];
 
   if ([self->script length] == 0)
     [ms appendString:@" no script"];

--- a/sope-appserver/NGObjWeb/Templates/WODParser.m
+++ b/sope-appserver/NGObjWeb/Templates/WODParser.m
@@ -271,7 +271,7 @@ static NSException *_makeException(NSException *_exception,
   [ui setObject:[NumberClass numberWithInt:_idx]     forKey:@"position"];
 
   if (!atEof && (_idx > 0)) {
-    register unsigned pos;
+    NSInteger pos;
     const unichar *startPos, *endPos;
 
     for (pos = _idx; (pos >= 0) && (_buffer[pos] != '\n'); pos--)

--- a/sope-appserver/NGObjWeb/Templates/WOHTMLParser.m
+++ b/sope-appserver/NGObjWeb/Templates/WOHTMLParser.m
@@ -246,7 +246,7 @@ static NSException *_makeHtmlException(NSException *_exception,
       [ui setObject:self forKey:@"handler"];
     
     if (!atEof && (_idx > 0)) {
-      register unsigned pos;
+      NSInteger pos;
       const unichar *startPos, *endPos;
 
       for (pos = _idx; (pos >= 0) && (_buffer[pos] != '\n'); pos--)

--- a/sope-appserver/NGObjWeb/Templates/WOTemplate.m
+++ b/sope-appserver/NGObjWeb/Templates/WOTemplate.m
@@ -133,7 +133,7 @@
       [ms appendFormat:@" url=%@", [self->url absoluteString]];
   }
   if (self->subcomponentInfos)
-    [ms appendFormat:@" #subcomponents=%i", [self->subcomponentInfos count]];
+    [ms appendFormat:@" #subcomponents=%i", (int)[self->subcomponentInfos count]];
   
   [ms appendString:@">"];
   return ms;

--- a/sope-appserver/NGObjWeb/Templates/WOxElemBuilder.m
+++ b/sope-appserver/NGObjWeb/Templates/WOxElemBuilder.m
@@ -191,7 +191,7 @@ static WOAssociation *yesAssoc = nil;
       }
     }
     else {
-      NSLog(@"%s: couldn't allocate builder (class=%@)", cn);
+      NSLog(@"couldn't allocate builder (class=%@)", cn);
       continue;
     }
   }

--- a/sope-appserver/NGObjWeb/WOComponent.m
+++ b/sope-appserver/NGObjWeb/WOComponent.m
@@ -1219,7 +1219,7 @@ static inline id _getExtraVar(WOComponent *self, NSString *_key) {
   if (self->parentComponent)
     [str appendFormat:@" parent=%@", [self->parentComponent name]];
   if (self->subcomponents)
-    [str appendFormat:@" #subs=%i", [self->subcomponents count]];
+    [str appendFormat:@" #subs=%i", (int)[self->subcomponents count]];
   
   if (self->componentFlags.isAwake)
     [str appendFormat:@" awake=0x%p", self->context];

--- a/sope-appserver/NGObjWeb/WOHTTPConnection.m
+++ b/sope-appserver/NGObjWeb/WOHTTPConnection.m
@@ -352,7 +352,7 @@ static BOOL logStream = NO;
   /* set content-length header */
   
   if ([content length] > 0) {
-    [_request setHeader:[NSString stringWithFormat:@"%d", [content length]]
+    [_request setHeader:[NSString stringWithFormat:@"%d", (int)[content length]]
               forKey:@"content-length"];
   }
 

--- a/sope-appserver/NGObjWeb/WOHttpAdaptor/WOHttpAdaptor.m
+++ b/sope-appserver/NGObjWeb/WOHttpAdaptor/WOHttpAdaptor.m
@@ -427,7 +427,7 @@ static BOOL     debugOn                      = NO;
 }
 
 - (NGActiveSocket *)_accept {
-  NGActiveSocket *connection;
+  id<NGActiveSocket>  connection;
   id<NGSocketAddress> remote;
 
   NS_DURING {
@@ -450,7 +450,7 @@ static BOOL     debugOn                      = NO;
   }
   NS_ENDHANDLER;
 
-  return connection;
+  return (NGActiveSocket*)connection;
 }
 
 - (void)_handleConnection:(NGActiveSocket *)connection {

--- a/sope-appserver/NGObjWeb/WOHttpAdaptor/WOHttpTransaction.m
+++ b/sope-appserver/NGObjWeb/WOHttpAdaptor/WOHttpTransaction.m
@@ -1021,9 +1021,9 @@ static __inline__ const char *monthAbbr(int m) {
   [buf appendString:@"\" "];
   [buf appendFormat:@"%i %i",  
          [_response status],
-         [[_response content] length]];
+         (int)[[_response content] length]];
   if (doExtLog)
-    [buf appendFormat:@"/%i", [[_request content] length]];
+    [buf appendFormat:@"/%i", (int)[[_request content] length]];
   
   /* append duration */
   if (lstartDate != nil)

--- a/sope-appserver/NGObjWeb/WOHttpAdaptor/WORequest+Adaptor.m
+++ b/sope-appserver/NGObjWeb/WOHttpAdaptor/WORequest+Adaptor.m
@@ -35,7 +35,7 @@
   if (pi == nil) pi = [[NSProcessInfo processInfo] retain];
   
   tmp = [pi procStatDictionary];
-  ASSIGN(self->startDate,       _startDate);
+  ASSIGN(self->startDate,       (NSCalendarDate*)_startDate);
   ASSIGN(self->startStatistics, tmp);
 }
 

--- a/sope-appserver/NGObjWeb/WOResponse.m
+++ b/sope-appserver/NGObjWeb/WOResponse.m
@@ -305,7 +305,7 @@ static __inline__ char *monthName(int m) {
     if ([data length] == 0)
       [ms appendString:@" empty-content"];
     else
-      [ms appendFormat:@" content-size=%i", [data length]];
+      [ms appendFormat:@" content-size=%i", (int)[data length]];
   }
   else
     [ms appendString:@" no-content"];

--- a/sope-appserver/NGObjWeb/WOSessionStore.m
+++ b/sope-appserver/NGObjWeb/WOSessionStore.m
@@ -49,7 +49,7 @@
   WOSession *session;
   *(&session) = nil;
   
-  SYNCHRONIZED(self) { // this must become a condition lock !!!
+  SYNCHRONIZED((id)self) { // this must become a condition lock !!!
     if (![self->checkedOutSessions containsObject:_sid]) {
       if ((session = [self restoreSessionWithID:_sid]))
         [self->checkedOutSessions addObject:_sid];
@@ -66,7 +66,7 @@
   NSString *sid;
   *(&sid) = [[_context session] sessionID];
   
-  SYNCHRONIZED(self) { // this must become a condition lock !!!
+  SYNCHRONIZED((id)self) { // this must become a condition lock !!!
     [self saveSessionForContext:_context];
     
     if ([self->checkedOutSessions containsObject:sid])

--- a/sope-appserver/NGObjWeb/WOSimpleHTTPParser.m
+++ b/sope-appserver/NGObjWeb/WOSimpleHTTPParser.m
@@ -449,7 +449,7 @@ static NSString *stringForHeaderName(char *p) { /* Note: arg is _not_ const */
   
   while ((e = [self readNextLine]) == nil) {
     unsigned char *p, *v;
-    unsigned int  idx;
+    int  idx;
     NSString *headerName;
     NSString *headerValue;
     

--- a/sope-appserver/NGObjWeb/WOStatisticsStore.m
+++ b/sope-appserver/NGObjWeb/WOStatisticsStore.m
@@ -35,7 +35,7 @@
   unsigned       zippedResponsesCount;
   unsigned       totalZippedSize;
   unsigned       largestResponseSize;
-  unsigned       smallestResponseSize;
+  NSInteger      smallestResponseSize;
   NSTimeInterval minimumDuration;
   NSTimeInterval maximumDuration;
   NSTimeInterval totalDuration;
@@ -420,7 +420,7 @@ static id mkdbl(double d) {
   /* response */
   
   [result appendFormat:@"%i %i",
-            [_response status], [[_response content] length]];
+            [_response status], (int)[[_response content] length]];
   
   if ((startDate = [request startDate]) != nil) {
     NSTimeInterval duration;

--- a/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
@@ -749,7 +749,7 @@ static inline BOOL isTokStopChar(unichar c) {
     }
     else if ([[(EOAndQualifier *)q qualifiers] count] != 3) {
       NSLog(@"  INVALID: expected 3 subqualifiers, got %i !",
-	    [[(EOAndQualifier *)q qualifiers] count]);
+	    (int)[[(EOAndQualifier *)q qualifiers] count]);
     }
 
     /* check sortordering */
@@ -767,7 +767,7 @@ static inline BOOL isTokStopChar(unichar c) {
     }
     else if ([props count] != 14) {
       NSLog(@"  INVALID: invalid attribute count, expected 14, got %i.",
-	    [props count]);
+	    (int)[props count]);
     }
   }
   

--- a/sope-appserver/NGObjWeb/WebDAV/SoWebDAVRenderer.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoWebDAVRenderer.m
@@ -1311,7 +1311,7 @@ static BOOL         useRelativeURLs = YES;
     [r appendContentString:@"204 No Content"];
   else {
     NSString *s;
-    s = [NSString stringWithFormat:@"%i code%i"];
+    s = [NSString stringWithFormat:@"%i code", _code];
     [r appendContentString:s];
   }
   [r appendContentString:@"</D:status>"];

--- a/sope-appserver/NGObjWeb/WebDAV/SoWebDAVValue.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoWebDAVValue.m
@@ -78,7 +78,7 @@
 	
 	if ((p = [encNS objectForKey:ns]) == nil) {
 	  if ((p = [_prefixes objectForKey:ns]) == nil) {
-	    p = [NSString stringWithFormat:@"a%i", [encNS count]];
+	    p = [NSString stringWithFormat:@"a%i", (int)[encNS count]];
 	    [encNS setObject:p forKey:ns];
 	    [ms appendString:@" xmlns:"];
 	    [ms appendString:p];

--- a/sope-appserver/NGObjWeb/_WOStringTable.m
+++ b/sope-appserver/NGObjWeb/_WOStringTable.m
@@ -162,7 +162,7 @@ static NSStringEncoding stringFilesEncoding = NSUTF8StringEncoding;
   [ms appendFormat:@"<0x%p[%@]: ", self, NSStringFromClass([self class])];
   
   if (self->path)     [ms appendFormat:@" path='%@'",   self->path];
-  if (self->data)     [ms appendFormat:@" strings=#%d", [self->data count]];
+  if (self->data)     [ms appendFormat:@" strings=#%d", (int)[self->data count]];
   if (self->lastRead) [ms appendFormat:@" loaddate=%@", self->lastRead];
   
   [ms appendString:@">"];

--- a/sope-appserver/WEExtensions/JSStringTable.m
+++ b/sope-appserver/WEExtensions/JSStringTable.m
@@ -177,7 +177,7 @@
   }
   else {
     /* generate link to table file */
-    NSMutableDictionary *qd;
+    NSDictionary *qd;
     NSString *url;
     id product = nil;
     

--- a/sope-appserver/WEExtensions/WEMonthOverview.m
+++ b/sope-appserver/WEExtensions/WEMonthOverview.m
@@ -510,7 +510,7 @@ _takeValuesInCell(WEMonthOverview *self, WORequest *request,
   /* fill up remaining slots with empty arrays */
   for (i = 0; i < MatrixSize; i++) {
     if (self->matrix[i] == nil)
-      self->matrix[i] = [[NSArray alloc] init];
+      self->matrix[i] = (id)[[NSArray alloc] init];
   }
 }
 

--- a/sope-appserver/WEExtensions/WEResourceKey.m
+++ b/sope-appserver/WEExtensions/WEResourceKey.m
@@ -65,7 +65,7 @@
 
 /* equality */
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   if (self->hashValue == 0) {
     /* don't know whether this is smart, Nat! needs to comment ;-) */
     self->hashValue = [self->name hash];

--- a/sope-appserver/WEExtensions/WEResourceManager.m
+++ b/sope-appserver/WEExtensions/WEResourceManager.m
@@ -620,7 +620,7 @@ checkCache(NSDictionary *_cache, WEResourceKey *_key,
     }
     [ms appendString:_name];
     [ms appendFormat: @"?lm=%u",
-        (NSUInteger) [lastModified timeIntervalSince1970]];
+        (unsigned) [lastModified timeIntervalSince1970]];
       
     url = ms;
     if (debugOn) [self debugWithFormat:@"FOUND: '%@'", url];

--- a/sope-appserver/WEExtensions/WETableCalcMatrix.m
+++ b/sope-appserver/WEExtensions/WETableCalcMatrix.m
@@ -89,8 +89,8 @@ static NSNull *null = nil;
                      @"<0x%p[%@]: object=0x%p start=%d len=%d>",
                      self, NSStringFromClass([self class]),
                      [self object],
-                     self->range.location,
-                     self->range.length];
+                     (int)self->range.location,
+                     (int)self->range.length];
 }
 
 @end /* WETableCalcMatrixSpan */

--- a/sope-appserver/WEExtensions/WETableView/WETableView.m
+++ b/sope-appserver/WEExtensions/WETableView/WETableView.m
@@ -1525,9 +1525,9 @@ static inline void _applyState_(WETableView *self, WOComponent *cmp) {
         result = [self decreaseBatchSizeInContext:_ctx];
       else {
         if (self->identifier == nil) {
-          unsigned idx;
+          NSInteger idx;
       
-          idx   = [idxId unsignedIntValue];
+          idx   = [idxId integerValue];
           if (idx < [self->allObjects count] && idx >= 0) {
             _applyItems_(self, cmp, idx);
           }

--- a/sope-appserver/WOExtensions/WOTabPanel.m
+++ b/sope-appserver/WOExtensions/WOTabPanel.m
@@ -259,7 +259,7 @@
                      inComponent:sComponent];
   
   [_response appendContentString:@"</tr><tr><td colspan=\""];
-  s = [[NSString alloc] initWithFormat:@"%d",[ttabs count]];
+  s = [[NSString alloc] initWithFormat:@"%d",(int)[ttabs count]];
   [_response appendContentString:s];
   [s release];
   [_response appendContentString:@"\" bgcolor=\""];

--- a/sope-core/EOControl/EOFetchSpecification.m
+++ b/sope-core/EOControl/EOFetchSpecification.m
@@ -291,7 +291,7 @@
       [ma release];
     }
     else
-      lHints = [self->hints retain];
+      lHints = (id)[self->hints retain];
   }
   else 
     lHints = nil;

--- a/sope-core/EOControl/EONull.m
+++ b/sope-core/EOControl/EONull.m
@@ -32,15 +32,15 @@
 @implementation EONull
 
 + (id)allocWithZone:(NSZone *)_zone {
-  return [NSNull allocWithZone:_zone];
+  return (EONull*)[NSNull allocWithZone:_zone];
 }
 
 + (NSNull *)null {
-  return [NSNull null];
+  return (EONull*)[NSNull null];
 }
 
 - (id)self {
-  return [NSNull null];
+  return (EONull*)[NSNull null];
 }
 
 @end

--- a/sope-core/NGExtensions/FdExt.subproj/NGPropertyListParser.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NGPropertyListParser.m
@@ -453,7 +453,7 @@ static NSException *_makeException(NSException *_exception,
           }
         */
         if (!atEof && (_idx > 0)) {
-            register unsigned pos;
+            NSInteger pos;
             const unsigned char *startPos, *endPos;
 
             for (pos = _idx; (pos > 0) && (_buffer[pos] != '\n'); pos--)

--- a/sope-core/NGExtensions/FdExt.subproj/NSException+misc.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSException+misc.m
@@ -85,7 +85,7 @@
 
 - (id)copyWithZone:(NSZone *)_zone {
   // TODO: should make a real copy?
-  return [self retain];
+  return (id)[self retain];
 }
 
 @end /* NSException(NGMiscellaneous) */

--- a/sope-core/NGExtensions/FdExt.subproj/NSObject+Values.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSObject+Values.m
@@ -82,7 +82,7 @@
 
 + (NSString *) stringWithUnsignedLongLong: (unsigned long long)value
 {
-  return [NSString stringWithFormat: @"0x%.16"PRIx64, value];
+  return [NSString stringWithFormat: @"0x%.16llx", value];
 }
 
 - (BOOL)boolValue {

--- a/sope-core/NGExtensions/FdExt.subproj/NSString+Encoding.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSString+Encoding.m
@@ -209,7 +209,7 @@ static char *iconv_wrapper(id self, char *_src, unsigned _srcLen,
   tm           = outbuf;
   outbytesleft = outlen;
 
-  write = iconv(type, &inbuf, &inbytesleft, &tm, &outbytesleft);
+  write = iconv(type, (void*)&inbuf, &inbytesleft, &tm, &outbytesleft);
 
   if (write == (size_t)-1) {
     if (errno == EILSEQ) {

--- a/sope-core/NGExtensions/NGDirectoryEnumerator.m
+++ b/sope-core/NGExtensions/NGDirectoryEnumerator.m
@@ -54,7 +54,7 @@
 {
   self->fileManager = _fm
     ? [_fm retain]
-    : [[NSFileManager defaultManager] retain];
+    : (id)[[NSFileManager defaultManager] retain];
 
   self->pathStack = [[NSMutableArray alloc] init];
   self->enumStack = [[NSMutableArray alloc] init];

--- a/sope-core/NGStreams/NGBufferedStream.m
+++ b/sope-core/NGStreams/NGBufferedStream.m
@@ -66,7 +66,7 @@ static Class DataStreamClass = Nil;
   }
   if (*(Class *)_source == DataStreamClass) {
     [self release];
-    return [_source retain];
+    return (id)[_source retain];
   }
 
   if ((self = [super initWithSource:_source])) {
@@ -90,7 +90,7 @@ static Class DataStreamClass = Nil;
   }
   if (*(Class *)_source == DataStreamClass) {
     [self release];
-    return [_source retain];
+    return (id)[_source retain];
   }
 
   if ((self = [super initWithInputSource:_source])) {
@@ -109,7 +109,7 @@ static Class DataStreamClass = Nil;
   }
   if (*(Class *)_src == DataStreamClass) {
     [self release];
-    return [_src retain];
+    return (id)[_src retain];
   }
 
   if ((self = [super initWithOutputSource:_src])) {

--- a/sope-core/NGStreams/NGByteBuffer.m
+++ b/sope-core/NGStreams/NGByteBuffer.m
@@ -44,7 +44,7 @@ static Class DataStreamClass = Nil;
   DataStreamClass   = NSClassFromString(@"NGDataStream");
 }
 
-+ (int)version {
++ (NSInteger)version {
   return [super version] + 1;
 }
 
@@ -61,7 +61,7 @@ static Class DataStreamClass = Nil;
   }
   if (*(Class *)_source == DataStreamClass) {
     [self release];
-    return [_source retain];
+    return (id)[_source retain];
   }
   if ((self = [super initWithSource:_source])) {
     unsigned size = 0;

--- a/sope-core/NGStreams/NGByteCountStream.m
+++ b/sope-core/NGStreams/NGByteCountStream.m
@@ -87,7 +87,7 @@
   {
     register unsigned char *byteBuffer = _buf;
 
-    for (_len = result - 1; _len >= 0; _len--, byteBuffer++) {
+    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteReadCount++;
     }
@@ -106,7 +106,7 @@
   {
     register unsigned char *byteBuffer = (unsigned char *)_buf;
 
-    for (_len = result - 1; _len >= 0; _len--, byteBuffer++) {
+    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteWriteCount++;
     }

--- a/sope-core/NGStreams/NGCTextStream.m
+++ b/sope-core/NGStreams/NGCTextStream.m
@@ -265,7 +265,7 @@ static void _flushAtExit(void) {
                  format:
                    @"called writeCharacter: with character code (0x%X)"
                    @" exceeding the maximum system character code (0x%X)",
-                   _character, ((sizeof(unsigned char) * 256) - 1)];
+                   _character, (int)((sizeof(unsigned char) * 256) - 1)];
   }
 
   c = _character;

--- a/sope-core/NGStreams/NGConcreteStreamFileHandle.m
+++ b/sope-core/NGStreams/NGConcreteStreamFileHandle.m
@@ -118,7 +118,7 @@
 
   *(&data) = [NSMutableData dataWithCapacity:2048];
   *(&bs) = [self->stream isKindOfClass:[NGBufferedStream class]]
-    ? [self->stream retain]
+    ? (id)[self->stream retain]
     : [(NGBufferedStream *)[NGBufferedStream alloc] 
           initWithSource:self->stream];
 

--- a/sope-core/NGStreams/NGLocalSocketAddress.m
+++ b/sope-core/NGStreams/NGLocalSocketAddress.m
@@ -77,8 +77,8 @@ static NSString *socketDirectoryPath = @"/tmp";
         sizeof(((struct sockaddr_un *)self->address)->sun_path)) {
       
       NSLog(@"LocalDomain name too long: maxlen=%i, len=%i, path=%@",
-            sizeof(((struct sockaddr_un *)self->address)->sun_path),
-            [_path cStringLength],
+            (int)sizeof(((struct sockaddr_un *)self->address)->sun_path),
+            (int)[_path cStringLength],
             _path);
       [NSException raise:NSInvalidArgumentException
                    format:@"path to long as local domain socket address !"];
@@ -100,8 +100,8 @@ static NSString *socketDirectoryPath = @"/tmp";
   int      addressCounter = 0;
   NSString *newPath;
   
-  newPath = [NSString stringWithFormat:@"_ngsocket_%p_%p_%03d",
-                        getpid(), [NSThread currentThread], addressCounter];
+  newPath = [NSString stringWithFormat:@"_ngsocket_%d_%p_%03d",
+                        (int)getpid(), [NSThread currentThread], addressCounter];
   newPath = [socketDirectoryPath stringByAppendingPathComponent:newPath];
 
   return [self initWithPath:newPath];

--- a/sope-gdl1/GDLAccess/EOAttribute.m
+++ b/sope-gdl1/GDLAccess/EOAttribute.m
@@ -84,7 +84,7 @@ static EONull   *null = nil;
 }
 
 // Is equal only if same name; used to make aliasing ordering stable
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->name hash];
 }
 

--- a/sope-gdl1/GDLAccess/EODatabase.m
+++ b/sope-gdl1/GDLAccess/EODatabase.m
@@ -185,7 +185,7 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
   if ([self hasOpenChannels]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabase:%x: All channels must be closed when changing "
+              @"EODatabase:%@: All channels must be closed when changing "
               @"uniquing mode in the EODatabase, "
               @"in [EODatabase setUniquesObjects:]",
 		 self];
@@ -203,7 +203,7 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
   if ([self hasOpenChannels]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabase:%x: All channels must be closed when changing "
+              @"EODatabase:%@: All channels must be closed when changing "
               @"snapshoting mode in the EODatabase, "
               @"in [EODatabase setKeepsSnapshots:]",
 		 self];
@@ -328,14 +328,14 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
   if (_object == nil) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-		   @"EODatabase:%x: Cannot record null object, "
+		   @"EODatabase:%@: Cannot record null object, "
   		   @"in [EODatabase recordObject:primaryKey:entity:snapshot:]",
 		   self];
   }
   if ((_entity == nil) && self->flags.isUniquingObjects) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabase:%x: Cannot record object with null entity "
+              @"EODatabase:%@: Cannot record object with null entity "
               @"when the database is uniquing objects, "
               @"in [EODatabase recordObject:primaryKey:entity:snapshot:]",
 		 self];
@@ -344,7 +344,7 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
   if ((_key == nil) && self->flags.isUniquingObjects) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabase:%x: Cannot record object with null key "
+              @"EODatabase:%@: Cannot record object with null key "
               @"when the database is uniquing objects, "
               @"in [EODatabase recordObject:primaryKey:entity:snapshot:]",
 		 self];
@@ -352,7 +352,7 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
   if ((_snapshot == nil) && self->flags.isKeepingSnapshots) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabase:%x: Cannot record object with null snapshot "
+              @"EODatabase:%@: Cannot record object with null snapshot "
               @"when the database is keeping snapshots, "
               @"in [EODatabase recordObject:primaryKey:entity:snapshot:]",
 		 self];
@@ -408,7 +408,7 @@ static inline void _removeDatabaseInstance(EODatabase *_db) {
 
 - (void)reportError:(NSString*)error {
   if (self->flags.isLoggingWarnings)
-    NSLog(@"EODatabase:%x:%@", self, error);
+    NSLog(@"EODatabase:%@:%@", self, error);
 }
 
 @end /* EODatabase */

--- a/sope-gdl1/GDLAccess/EODatabaseChannel.m
+++ b/sope-gdl1/GDLAccess/EODatabaseChannel.m
@@ -593,7 +593,7 @@ NSString *EODatabaseChannelDidLockObjectName =
   }
   // Record object in database context
   if (![new_pkey isEqual:old_pkey]) {
-    NSLog(@"WARNING: (%@) primary key changed from %@ to %@",
+    NSLog(@"WARNING: (%s) primary key changed from %@ to %@",
           __PRETTY_FUNCTION__, old_pkey, new_pkey);
     [databaseContext forgetObject:anObj];
   }

--- a/sope-gdl1/GDLAccess/EODatabaseContext.m
+++ b/sope-gdl1/GDLAccess/EODatabaseContext.m
@@ -118,7 +118,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if (self->transactionNestingLevel == 0) {
     [NSException raise:NSInternalInconsistencyException
 		 format:
-              @"EODatabaseContext:%x: No transaction in progress "
+              @"EODatabaseContext:%@: No transaction in progress "
               @"in %s", self, _function];
   }
 }
@@ -264,7 +264,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
       (unsigned)transactionNestingLevel) {
     [NSException raise:NSInternalInconsistencyException
 		 format:
-              @"EODatabaseContext:%x:transaction nesting levels do not match: "
+              @"EODatabaseContext:%@:transaction nesting levels do not match: "
               @"database has %d, adaptor has %d, "
               @"in [EODatabaseContext beginTransaction]",
               self, transactionNestingLevel, 
@@ -295,7 +295,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
       (unsigned)self->transactionNestingLevel) {
     [NSException raise:NSInternalInconsistencyException
 		 format:
-              @"EODatabaseContext:%x:transaction nesting levels do not match: "
+              @"EODatabaseContext:%@:transaction nesting levels do not match: "
               @"database has %d, adaptor has %d, "
               @"in [EODatabaseContext commitTransaction]",
               self, transactionNestingLevel, 
@@ -325,7 +325,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
       (unsigned)self->transactionNestingLevel) {
     [NSException raise:NSInternalInconsistencyException
 		 format:
-              @"EODatabaseContext:%x:transaction nesting levels do not match: "
+              @"EODatabaseContext:%@:transaction nesting levels do not match: "
               @"database has %d, adaptor has %d, "
               @"in [EODatabaseContext rollbackTransaction]",
               self, transactionNestingLevel, 
@@ -385,7 +385,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if ([self transactionNestingLevel]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-        @"EODatabaseContext:%x: Cannot change update strategy "
+        @"EODatabaseContext:%@: Cannot change update strategy "
         @"when context has a transaction open, "
         @"in [EODatabaseContext setUpdateStrategy]",
         self];
@@ -483,14 +483,14 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if (_object == nil) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot forget null object, "
+              @"EODatabaseContext:%@: Cannot forget null object, "
               @"in [EODatabaseContext forgetObject]",
               self];
   }
   if ([EOFault isFault:_object]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot forget forget a fault object, "
+              @"EODatabaseContext:%@: Cannot forget forget a fault object, "
               @"in [EODatabaseContext forgetObject]",
               self];
   }
@@ -532,14 +532,14 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if (_object == nil) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record null object, "
+              @"EODatabaseContext:%@: Cannot record null object, "
               @"in [EODatabaseContext recordObject:primaryKey:entity:snapshot:]",
               self];
   }
   if ((_entity == nil) && self->isUniquingObjects) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record object with null entity "
+              @"EODatabaseContext:%@: Cannot record object with null entity "
               @"when uniquing objects, "
               @"in [EODatabaseContext recordObject:primaryKey:entity:snapshot:]",
               self];
@@ -550,7 +550,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if ((_key == nil) && self->isUniquingObjects) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record object with null key "
+              @"EODatabaseContext:%@: Cannot record object with null key "
               @"when uniquing objects, "
               @"in [EODatabaseContext recordObject:primaryKey:entity:snapshot:]",
               self];
@@ -558,7 +558,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if ((snapshot == nil) && isKeepingSnapshots && ![EOFault isFault:_object]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record object with null snapshot "
+              @"EODatabaseContext:%@: Cannot record object with null snapshot "
               @"when keeping snapshots, "
               @"in [EODatabaseContext recordObject:primaryKey:entity:snapshot:]"
               @": snapshot=%s keepsSnapshots=%s isFault=%s",
@@ -665,14 +665,14 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if (_object == nil) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record null object as locked, "
+              @"EODatabaseContext:%@: Cannot record null object as locked, "
               @"in [EODatabaseContext recordLockedObject:]",
               self];
   }
   if ([EOFault isFault:_object]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-              @"EODatabaseContext:%x: Cannot record a fault object as locked, "
+              @"EODatabaseContext:%@: Cannot record a fault object as locked, "
               @"in [EODatabaseContext recordLockedObject:]",
               self];
   }
@@ -695,14 +695,14 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   if (_object == nil) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-               @"EODatabaseContext:%x: Cannot record null object as updatetd, "
+               @"EODatabaseContext:%@: Cannot record null object as updatetd, "
                @"in [EODatabaseContext recordUpdatedObject:]",
                self];
   }
   if ([EOFault isFault:_object]) {
     [NSException raise:NSInvalidArgumentException
 		 format:
-               @"EODatabaseContext:%x: Cannot record fault object as updated, "
+               @"EODatabaseContext:%@: Cannot record fault object as updated, "
                @"in [EODatabaseContext recordUpdatedObject:]",
                self];
   }
@@ -728,7 +728,7 @@ static inline void _checkTxInProgress(EODatabaseContext *self,
   return [NSString stringWithFormat:
 		     @"<%@[0x%p]: #channels=%i tx-nesting=%i>",
                      NSStringFromClass([self class]), self,
-                     [self->channels count],
+                     (int)[self->channels count],
                      [self transactionNestingLevel]];
 }
 

--- a/sope-gdl1/GDLAccess/EODatabaseFault.m
+++ b/sope-gdl1/GDLAccess/EODatabaseFault.m
@@ -78,7 +78,7 @@ typedef struct {
 		       @"to fault",
 		       NSStringFromClass([fault class]),
 #if defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) || (__GNU_LIBOBJC__ >= 20100911)
-		       class_getInstanceSize([self class])];
+		       (int)class_getInstanceSize([self class])];
 #else
 			   ((Class)self)->instance_size];
 #endif
@@ -130,7 +130,7 @@ typedef struct {
 {
   EODatabaseFault *fault;
     
-  fault = [NSMutableArray allocWithZone:zone];
+  fault = (EODatabaseFault*)[NSMutableArray allocWithZone:zone];
 
 #if defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) || (__GNU_LIBOBJC__ >= 20100911)
   if (class_getInstanceSize([fault class]) < class_getInstanceSize([self class])) {
@@ -140,11 +140,11 @@ typedef struct {
         (void)[fault autorelease];
 	[NSException raise:NSInvalidArgumentException
 		     format:
-                    @"Instances from class %s must be at least %d "
+                    @"Instances from class %@ must be at least %d "
                     @"in size to fault",
                     NSStringFromClass([fault class]),
 #if defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) || (__GNU_LIBOBJC__ >= 20100911)
-                    class_getInstanceSize([self class])];
+                    (int)class_getInstanceSize([self class])];
 #else
 					((Class)self)->instance_size];
 #endif

--- a/sope-gdl1/GDLAccess/EODatabaseFaultResolver.m
+++ b/sope-gdl1/GDLAccess/EODatabaseFaultResolver.m
@@ -191,7 +191,7 @@
 
 - (NSString *)descriptionForObject:(id)_fault {
   return [NSString stringWithFormat:
-                   @"<Array fault 0x%x (qualifier=%@, order=%@, channel=%@)>",
+                   @"<Array fault %p (qualifier=%@, order=%@, channel=%@)>",
                    _fault, qualifier, fetchOrder, channel];
 }
 
@@ -302,7 +302,7 @@
 
 - (NSString *)descriptionForObject:(id)_fault {
   return [NSString stringWithFormat:
-                     @"<Object fault 0x%X "
+                     @"<Object fault %p "
                      @"(class=%@, entity=%@, key=%@, channel=%@)>",
                      _fault,
                      NSStringFromClass(targetClass), 

--- a/sope-gdl1/GDLAccess/EOEntity.m
+++ b/sope-gdl1/GDLAccess/EOEntity.m
@@ -106,7 +106,7 @@ static int _compareByName(id obj1, id obj2, void * context);
 }
 
 // Is equal only if same name; used to make aliasing ordering stable
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [name hash];
 }
 

--- a/sope-gdl1/GDLAccess/EOFault.m
+++ b/sope-gdl1/GDLAccess/EOFault.m
@@ -294,7 +294,7 @@ static inline void _resolveFault(EOFault *self) {
 }
 
 + (id)self {
-  _resolveFault(self);
+  _resolveFault((id)self);
   return self;
 }
 

--- a/sope-gdl1/GDLAccess/EOModel.m
+++ b/sope-gdl1/GDLAccess/EOModel.m
@@ -416,7 +416,7 @@ void EOModel_linkCategories(void) {
   if ((s = [self adaptorName]))      [ms appendFormat:@" adaptor=%@", s];
   if ((s = [self adaptorClassName])) [ms appendFormat:@" adaptor-class=%@", s];
   
-  [ms appendFormat:@" #entities=%d", [self->entities count]];
+  [ms appendFormat:@" #entities=%d", (int)[self->entities count]];
   
   [ms appendString:@">"];
   return ms;

--- a/sope-gdl1/GDLAccess/EOObjectUniquer.m
+++ b/sope-gdl1/GDLAccess/EOObjectUniquer.m
@@ -49,7 +49,7 @@ static BOOL uniquerCompare(NSMapTable *table, EOUniquerRecord *rec1,
 
 static NSString* uniqDescription(NSMapTable *t, EOUniquerRecord* rec) {
   return [NSString stringWithFormat:
-                     @"<<pkey:%08x entity:%08x object:%08x snapshot:%08x>>",
+                     @"<<pkey:%p entity:%p object:%p snapshot:%p>>",
                      rec->pkey, rec->entity, rec->object, rec->snapshot];
 }
 

--- a/sope-gdl1/GDLAccess/EOPrimaryKeyDictionary.m
+++ b/sope-gdl1/GDLAccess/EOPrimaryKeyDictionary.m
@@ -263,14 +263,14 @@
     return nil;
 }
 
-- (unsigned int)count {
+- (NSUInteger)count {
     return self->count;
 }
 - (BOOL)isNotEmpty {
   return self->count > 0 ? YES : NO;
 }
 
-- (unsigned int)hash {
+- (NSUInteger)hash {
     return self->count;
 }
 

--- a/sope-gdl1/GDLAccess/EORecordDictionary.m
+++ b/sope-gdl1/GDLAccess/EORecordDictionary.m
@@ -55,7 +55,7 @@ static NSDictionary *emptyDict = nil;
 - (id)init  {
   RELEASE(self);
   if (emptyDict == nil) emptyDict = [[NSDictionary alloc] init];
-  return [emptyDict retain];
+  return (id)[emptyDict retain];
 }
 
 - (id)initWithObjects:(id *)_objects forKeys:(id *)_keys 
@@ -64,12 +64,12 @@ static NSDictionary *emptyDict = nil;
   if (_count == 0) {
         RELEASE(self);
 	if (emptyDict == nil) emptyDict = [[NSDictionary alloc] init];
-	return [emptyDict retain];
+	return (id)[emptyDict retain];
   }
   
   if (_count == 1) {
         RELEASE(self);
-        return [[NSDictionary alloc]
+        return (id)[[NSDictionary alloc]
                               initWithObjects:_objects forKeys:_keys
                               count:_count];
   }

--- a/sope-gdl1/GDLAccess/EORelationship.m
+++ b/sope-gdl1/GDLAccess/EORelationship.m
@@ -84,7 +84,7 @@ static EONull *null = nil;
 }
 
 // Is equal only if same name; used to make aliasing ordering stable
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->name hash];
 }
 
@@ -405,7 +405,7 @@ static EONull *null = nil;
     NS_DURING
       [self setDefinition:self->definition];
     NS_HANDLER {
-      NSLog([localException reason]);
+      NSLog(@"%@", [localException reason]);
       [[self->entity model] errorInReading];
     }
     NS_ENDHANDLER;

--- a/sope-gdl1/PostgreSQL/NSData+PGVal.m
+++ b/sope-gdl1/PostgreSQL/NSData+PGVal.m
@@ -84,7 +84,7 @@ static NSData *EmptyData = nil;
 
   if (doDebug) {
     NSLog(@"Note: made string (len=%i) for data (len=%i), type %@",
-	  [str length], [self length], _type);
+	  (int)[str length], (int)[self length], _type);
   }
   
   if ((len = [_type length]) == 0) {
@@ -108,7 +108,7 @@ static NSData *EmptyData = nil;
       t = [[str stringValueForPostgreSQLType:_type 
 		attribute:_attribute] copy];
       [str release];
-      if (doDebug) NSLog(@"  result len %i", [t length]);
+      if (doDebug) NSLog(@"  result len %i", (int)[t length]);
       return [t autorelease];
     }
   }

--- a/sope-gdl1/PostgreSQL/PostgreSQL72Channel.m
+++ b/sope-gdl1/PostgreSQL/PostgreSQL72Channel.m
@@ -203,7 +203,7 @@ static int openConnectionCount = 0;
   /* set client encoding */
 #if NG_SET_CLIENT_ENCODING
   if (![self->connection setClientEncoding:PGClientEncoding]) {
-    NSLog(@"WARNING: could not set client encoding to: '%s'", 
+    NSLog(@"WARNING: could not set client encoding to: '%@'", 
 	  PGClientEncoding);
   }
 #endif

--- a/sope-gdl1/PostgreSQL/PostgreSQL72DataTypeMappingException.m
+++ b/sope-gdl1/PostgreSQL/PostgreSQL72DataTypeMappingException.m
@@ -46,7 +46,7 @@
   typeName = _dt;
 
   if (typeName == nil)
-    typeName = [NSString stringWithFormat:@"Oid[%i]", _dt];
+    typeName = [NSString stringWithFormat:@"Oid[%i]", (int)_dt];
   
   // TODO: fix for Cocoa/gstep Foundation?
   [self setName:@"DataTypeMappingNotSupported"];

--- a/sope-ldap/NGLdap/NGLdapConnection.m
+++ b/sope-ldap/NGLdap/NGLdapConnection.m
@@ -1223,7 +1223,7 @@ static void freeMods(LDAPMod **mods) {
   
   if ([self doesUseCache]) {
     [s appendFormat:@" cache[to=%.2fs,mem=%i]",
-         [self cacheTimeout], [self cacheMaxMemoryUsage]];
+         [self cacheTimeout], (int)[self cacheMaxMemoryUsage]];
   }
   
   [s appendString:@">"];

--- a/sope-ldap/NGLdap/NGLdapFileManager.m
+++ b/sope-ldap/NGLdap/NGLdapFileManager.m
@@ -317,7 +317,7 @@ static NSArray  *fileInfoAttrs    = nil;
   short count;
   
   if ((dn = [self dnForPath:_path]) == nil)
-    return NO;
+    return nil;
   
   entry = [self->connection entryAtDN:dn attributes:fileInfoAttrs];
   if (entry == nil)
@@ -432,7 +432,7 @@ static NSArray  *fileInfoAttrs    = nil;
   NGLdapEntry     *entry;
   
   if ((dn = [self dnForPath:_path]) == nil)
-    return NO;
+    return nil;
   
   entry = [self->connection entryAtDN:dn attributes:nil];
   if (entry == nil)

--- a/sope-ldap/NGLdap/NGLdapGlobalID.m
+++ b/sope-ldap/NGLdap/NGLdapGlobalID.m
@@ -53,7 +53,7 @@
 
 /* equality */
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->dn hash] + [self->host hash];
 }
 

--- a/sope-mime/NGImap4/NGImap4Client.m
+++ b/sope-mime/NGImap4/NGImap4Client.m
@@ -646,7 +646,7 @@ static NSMutableDictionary *namespaces;
 
   if (![self passwordIsSimple])
     s = [NSString stringWithFormat:@"login \"%@\" {%d}",
-		  self->login, plength];
+		  self->login, (int)plength];
   else
     s = [NSString stringWithFormat:@"login \"%@\" \"%@\"",
           self->login, self->password];
@@ -962,9 +962,9 @@ static NSMutableDictionary *namespaces;
 
   if (_folder == nil)
     return nil;
-  if ((_entry == nil))
+  if (_entry == nil)
     return nil;
-  if ((_attribute == nil))
+  if (_attribute == nil)
     return nil;
   if ((_folder = [self _folder2ImapFolder:_folder]) == nil)
     return nil;
@@ -994,11 +994,11 @@ static NSMutableDictionary *namespaces;
   
   if (_folder == nil)
     return nil;
-  if ((_entry == nil))
+  if (_entry == nil)
     return nil;
-  if ((_attribute == nil))
+  if (_attribute == nil)
     return nil;
-  if ((_value == nil))
+  if (_value == nil)
     return nil;
   if ((_folder = [self _folder2ImapFolder:_folder]) == nil)
     return nil;
@@ -1186,7 +1186,7 @@ static NSMutableDictionary *namespaces;
 
   cmd  = [NSString stringWithFormat:
                      @"UID FETCH %llu:%llu (UID) (CHANGEDSINCE 1)",
-                   _uid, _uid];
+                   (unsigned long long)_uid, (unsigned long long)_uid];
   fetchres = [self processCommand:cmd];
   result   = [self->normer normalizeFetchResponse:fetchres];
   return result;
@@ -1203,7 +1203,7 @@ static NSMutableDictionary *namespaces;
   
   cmd  = [NSString stringWithFormat:
                      @"UID FETCH 1:* (UID) (CHANGEDSINCE %llu VANISHED)",
-                   _modseq];
+                   (unsigned long long)_modseq];
   fetchres = [self processCommand:cmd];
   result   = [[self->normer normalizeFetchResponse:fetchres] retain];
   [pool release];
@@ -1329,7 +1329,7 @@ static NSMutableDictionary *namespaces;
   
   icmd = [NSString stringWithFormat:@"append \"%@\" (%@) {%d}",
                    _folder, [flags componentsJoinedByString:@" "],
-                   [rfc822Data length]];
+                   (int)[rfc822Data length]];
   result = [self processCommand:icmd
                  withTag:YES withNotification:NO];
   

--- a/sope-mime/NGImap4/NGImap4Connection.m
+++ b/sope-mime/NGImap4/NGImap4Connection.m
@@ -1174,10 +1174,10 @@ NSArray *SOGoMailGetDirectChildren(NSArray *_array, NSString *_fn) {
   [ms appendFormat:@" created=%@", self->creationTime];
   
   if (self->subfolders != nil)
-    [ms appendFormat:@" #cached-folders=%d", [self->subfolders count]];
+    [ms appendFormat:@" #cached-folders=%d", (int)[self->subfolders count]];
   
   if (self->cachedUIDs != nil)
-    [ms appendFormat:@" #cached-uids=%d", [self->cachedUIDs count]];
+    [ms appendFormat:@" #cached-uids=%d", (int)[self->cachedUIDs count]];
   
   [ms appendString:@">"];
   return ms;

--- a/sope-mime/NGImap4/NGImap4FileManager.m
+++ b/sope-mime/NGImap4/NGImap4FileManager.m
@@ -225,7 +225,7 @@ static BOOL debugOn = NO;
   if ((folder = [self _lookupFolderAtPathString:_path]) == nil)
     return NO;
 
-  ASSIGN(self->currentFolder, folder);
+  ASSIGN(self->currentFolder, (id)folder);
 
   return YES;
 }

--- a/sope-mime/NGImap4/NGImap4FolderGlobalID.m
+++ b/sope-mime/NGImap4/NGImap4FolderGlobalID.m
@@ -62,7 +62,7 @@
 
 /* comparison */
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->absoluteName hash];
 }
 

--- a/sope-mime/NGImap4/NGImap4Functions.m
+++ b/sope-mime/NGImap4/NGImap4Functions.m
@@ -129,7 +129,7 @@ NGImap4Folder *_subFolderWithName
       if (debugFolderLookup) {
 	NSLog(@"  FAILED: %@", [[_parent context] lastException]);
       }
-      return NO;
+      return nil;
     }
   }
   if (debugFolderLookup) NSLog(@"  NOT FOUND.");

--- a/sope-mime/NGImap4/NGImap4Message.m
+++ b/sope-mime/NGImap4/NGImap4Message.m
@@ -243,8 +243,8 @@ static BOOL              ImapDebugEnabled  = NO;
 }
 
 - (void)markUnread {
-  if ([self isRead]);
-  [self removeFlag:@"seen"];
+  if ([self isRead])
+    [self removeFlag:@"seen"];
 }
 
 - (BOOL)isFlagged {
@@ -345,7 +345,7 @@ static BOOL              ImapDebugEnabled  = NO;
   return YES;
 }
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   return self->uid;
 }
 

--- a/sope-mime/NGImap4/NGImap4ResponseParser.m
+++ b/sope-mime/NGImap4/NGImap4ResponseParser.m
@@ -1463,7 +1463,7 @@ _purifyQuotedString(NSMutableString *quotedString) {
   NSString            *name  = nil;
   NSString            *entry  = nil;
   NSMutableDictionary *attributes = nil;
-  NSDictionary *d, *f;
+  NSMutableDictionary *d, *f;
 
   if (!_matchesString(self, "ANNOTATION "))
     return NO;
@@ -1511,7 +1511,7 @@ _purifyQuotedString(NSMutableString *quotedString) {
     [attributes setObject:value
            forKey:[key lowercaseString]];
 
-    [d setObject:[NSDictionary dictionaryWithDictionary:attributes]
+    [d setObject:[NSMutableDictionary dictionaryWithDictionary:attributes]
        forKey:entry];
   }
   _consumeIfMatch(self, ')');
@@ -2484,7 +2484,7 @@ static BOOL _parseBadUntaggedResponse(NGImap4ResponseParser *self,
 static BOOL _parseNoOrOkArguments(NGImap4ResponseParser *self,
                                   NGMutableHashMap *result_, NSString *_key) 
 {
-  NSString *obj;
+  id obj;
 
   obj = nil;
   

--- a/sope-mime/NGImap4/NGImap4ServerGlobalID.m
+++ b/sope-mime/NGImap4/NGImap4ServerGlobalID.m
@@ -65,7 +65,7 @@
 
 /* comparison */
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->login hash];
 }
 

--- a/sope-mime/NGImap4/NGSieveClient.m
+++ b/sope-mime/NGImap4/NGSieveClient.m
@@ -444,14 +444,14 @@ static BOOL     debugImap4         = NO;
     NSString *s;
     
     s = [NSString stringWithFormat:@"AUTHENTICATE \"PLAIN\" {%d+}\r\n%s",
-                  [auth length], [auth bytes]];
+                  (int)[auth length], [auth bytes]];
     map = [self processCommand:s];
   }
   else {
     NSString *s;
     
     s = [NSString stringWithFormat:@"AUTHENTICATE \"PLAIN\" {%d+}\r\n%s",
-                  [auth length], [auth bytes]];
+                  (int)[auth length], [auth bytes]];
     map = [self processCommand:s
                 logText:@"AUTHENTICATE \"PLAIN\" {%d+}\r\nLOGIN:PASSWORD\r\n"];
   }
@@ -548,7 +548,7 @@ static BOOL     debugImap4         = NO;
   s = [s stringByAppendingString:_name];
   s = [s stringByAppendingString:@"\" "];
   s = [s stringByAppendingFormat:@"{%d+}\r\n%@",
-         [_script lengthOfBytesUsingEncoding: NSUTF8StringEncoding],
+         (int)[_script lengthOfBytesUsingEncoding: NSUTF8StringEncoding],
          _script];
   map = [self processCommand:s];
   return [self normalizeResponse:map];

--- a/sope-mime/NGMail/NGMailAddress.m
+++ b/sope-mime/NGMail/NGMailAddress.m
@@ -66,7 +66,7 @@
   return NO;
 }
 
-- (unsigned)hash {
+- (NSUInteger)hash {
   return [self->address hash];
 }
 

--- a/sope-mime/NGMail/NGMailAddressParser.m
+++ b/sope-mime/NGMail/NGMailAddressParser.m
@@ -349,15 +349,15 @@ static inline id parseDomainLiteral(NGMailAddressParser *self, BOOL _guessMode) 
   uniString = [NSString stringWithCharacters:(unichar *)[_data bytes]
 			length:([_data length] / sizeof(unichar))];
 
-  return [(NGMailAddressParser *)self mailAddressParserWithString:uniString];
+  return [(id)self mailAddressParserWithString:uniString];
 }
 
-+ (id)mailAddressParserWithCString:(char *)_cString {
++ (id)mailAddressParserWithCString:(const char *)_cString {
   NSString *nsCString;
 
   nsCString = [NSString stringWithCString:_cString];
 
-  return [(NGMailAddressParser *)self mailAddressParserWithString:nsCString];
+  return [(id)self mailAddressParserWithString:nsCString];
 }
 
 + (id)mailAddressParserWithString:(NSString *)_string {

--- a/sope-mime/NGMail/NGMimeMessage.m
+++ b/sope-mime/NGMail/NGMimeMessage.m
@@ -230,7 +230,7 @@ static NGMimeType *defaultDataType = nil;
     if ([b length] < 512)
       [d appendFormat:@" body=%@", b];
     else
-      [d appendFormat:@" body[len=%i]", [b length]];
+      [d appendFormat:@" body[len=%i]", (int)[b length]];
   }
   else
     [d appendFormat:@" body=%@", b];

--- a/sope-mime/NGMime/NGMimeBodyPart.m
+++ b/sope-mime/NGMime/NGMimeBodyPart.m
@@ -206,10 +206,10 @@
   else if ([b isKindOfClass:[NSString class]] ||
            [b isKindOfClass:[NSData class]]) {
     if ([b length] < 512) {
-      [d appendFormat:@" bodyLen=%i body=%@", [b length], b];
+      [d appendFormat:@" bodyLen=%i body=%@", (int)[b length], b];
     }
     else
-      [d appendFormat:@" body[len=%i]", [b length]];
+      [d appendFormat:@" body[len=%i]", (int)[b length]];
   }
   else
     [d appendFormat:@" body=%@", b];

--- a/sope-mime/NGMime/NGMimeJoinedData.m
+++ b/sope-mime/NGMime/NGMimeJoinedData.m
@@ -168,7 +168,7 @@
   ms = [NSMutableString stringWithCapacity:128];
   [ms appendFormat:@"<0x%p[%@]:", self, NSStringFromClass([self class])];
   [ms appendFormat:@" joinedDataObjects=%d>",
-        [self->joinedDataObjects count]];
+        (int)[self->joinedDataObjects count]];
   [ms appendString:@">"];
   return ms;
 }

--- a/sope-mime/NGMime/NGMimePartGenerator.m
+++ b/sope-mime/NGMime/NGMimePartGenerator.m
@@ -92,7 +92,7 @@ static BOOL       debugOn = NO;
     self->result = nil;
   }
   self->result = (self->useMimeData)
-    ? [[NGMimeJoinedData alloc] init]
+    ? (NSMutableData*)[[NGMimeJoinedData alloc] init]
     : [[NSMutableData alloc] initWithCapacity:4096];
   
   if ([self->result respondsToSelector:@selector(methodForSelector:)]) {

--- a/sope-mime/NGMime/NGMimePartParser.m
+++ b/sope-mime/NGMime/NGMimePartParser.m
@@ -1025,7 +1025,7 @@ static NSString *fieldNameForCString(id self, char *_cstring, int _len) {
               NSMakeRange(self->dataIdx, self->byteLen - self->dataIdx)];
   if ([data length] != _len) {
     NSLog(@"%s[%i]: got wrong data %d _len %d", __PRETTY_FUNCTION__, __LINE__,
-          [data length], _len);
+          (int)[data length], _len);
     return nil;
   }
   return data;

--- a/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldParser.m
+++ b/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldParser.m
@@ -161,7 +161,7 @@ static NSTimeZone *parseTimeZone(const char *s, size_t len) {
     hours += 10 * (*(s + pos) - 48) + *(s + pos + 1) - 48;
     break;
   default:
-    NSLog (@"parseTimeZone: cannot parse time notation '%.*s'", len, s);
+    NSLog (@"parseTimeZone: cannot parse time notation '%.*s'", (int)len, s);
   }
 
   seconds += sign * (3600 * hours + 60 * minutes);

--- a/sope-xml/DOM/DOMQueryPathExpression.m
+++ b/sope-xml/DOM/DOMQueryPathExpression.m
@@ -318,7 +318,7 @@
   qpexpr = [DOMQueryPathExpression queryPathWithString:_expr];
   //NSLog(@"Expr: %@", qpexpr);
   
-  pred =
+  pred = (_DOMQPPredicateExpression*)
     [[_DOMQPPredicateQPExpression alloc] initWithQueryPathExpression:qpexpr];
   
   return [pred autorelease];

--- a/sope-xml/XmlRpc/NSNotification+XmlRpcCoding.m
+++ b/sope-xml/XmlRpc/NSNotification+XmlRpcCoding.m
@@ -30,7 +30,7 @@
 }
 
 + (id)decodeObjectWithXmlRpcCoder:(XmlRpcDecoder *)_coder {
-  self = [NSNotification notificationWithName:
+  self = (id)[NSNotification notificationWithName:
                            [_coder decodeStringForKey:@"name"]
                          object:[_coder decodeObjectForKey:@"object"]
                          userInfo:[_coder decodeStructForKey:@"userInfo"]];


### PR DESCRIPTION
… data type and casting inconsistencies. Also some string formatting fixes.

These are patches that come from a code cleanup exercise trying to clear as many clang compiler warnings as possible. But they should apply to any build environement.
 
Note that the SOPE and SOGo both build sucessfully after these and many other patches have been applied. Also, I've been running in production for a few days without any issues. However I have not done any unit testing.