### PR TITLE
Stage 2,3,4,5 and 6 of clang compiler warning patches.

### DIFF
--- a/sope-appserver/NGObjWeb/DynamicElements/WOHyperlinkInfo.m
+++ b/sope-appserver/NGObjWeb/DynamicElements/WOHyperlinkInfo.m
@@ -27,7 +27,7 @@
 @implementation WOHyperlinkInfo
 
 - (id)initWithConfig:(NSMutableDictionary *)_config {
-  unsigned count;
+  unsigned count = (unsigned)[_config count];
 
   self->sidInUrl = YES;
   

--- a/sope-appserver/NGObjWeb/NGHttp/NGHttpHeaderFieldParser.m
+++ b/sope-appserver/NGObjWeb/NGHttp/NGHttpHeaderFieldParser.m
@@ -31,7 +31,7 @@ static Class NSArrayClass = Nil;
 - (id)parseValue:(id)_data ofHeaderField:(NSString *)_field {
   unsigned              len   = 0;
   const unsigned char   *src  = NULL;
-  NGHttpHostHeaderField *value = nil;
+  id                     value = nil;
   NSString *str = nil;
 
   if ([_data isKindOfClass:[NSData class]]) {

--- a/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.h
+++ b/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.h
@@ -101,7 +101,7 @@
 - (BOOL)hasDefaultAccessDeclaration;
 - (void)declarePublic:(NSString *)_firstName, ...;
 - (void)declarePrivate:(NSString *)_firstName, ...;
-- (void)declareProtected:(NSString *)_perm:(NSString *)_firstName, ...;
+- (void)declareProtected:(NSString *)_perm :(NSString *)_firstName, ...;
 
 /* object security */
 

--- a/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.m
@@ -111,7 +111,7 @@
   va_end(va);
 }
 
-- (void)declareProtected:(NSString *)_perm:(NSString *)_firstName, ... {
+- (void)declareProtected:(NSString *)_perm :(NSString *)_firstName, ... {
   va_list  va;
   NSString *aname;
 

--- a/sope-appserver/NGObjWeb/WOComponent+Sync.m
+++ b/sope-appserver/NGObjWeb/WOComponent+Sync.m
@@ -87,7 +87,7 @@ void WOComponent_syncFromParent(WOComponent *self, WOComponent *_parent) {
 #if NeXT_RUNTIME
   takeValue = (void *)[self methodForSelector:@selector(takeValue:forKey:)];
 #elif GNUSTEP_BASE_LIBRARY
-  takeValue = (void*)method_get_imp(class_get_instance_method(self->isa,
+  takeValue = (void*)method_get_imp(class_get_instance_method(object_getClass(self),
                 @selector(setValue:forKey:)));
 #else  
   takeValue = (void*)method_get_imp(class_get_instance_method(self->isa,
@@ -148,7 +148,7 @@ void WOComponent_syncToParent(WOComponent *self, WOComponent *_parent) {
 #if NeXT_RUNTIME
   getValue = (void *)[self methodForSelector:@selector(valueForKey:)];
 #else
-  getValue = (void*)method_get_imp(class_get_instance_method(self->isa,
+  getValue = (void*)method_get_imp(class_get_instance_method(object_getClass(self),
                 @selector(valueForKey:)));
 #endif
   

--- a/sope-appserver/NGObjWeb/WOComponent.m
+++ b/sope-appserver/NGObjWeb/WOComponent.m
@@ -1037,7 +1037,7 @@ static inline id _getExtraVar(WOComponent *self, NSString *_key) {
 
 - (BOOL)logComponentVariableCreations {
   /* only if we have a subclass, we can store values in ivars ... */
-  return (self->isa != WOComponentClass) ? YES : NO;
+  return (object_getClass(self) != WOComponentClass) ? YES : NO;
 }
 
 #if !NG_USE_KVC_FALLBACK /* only override on libFoundation */
@@ -1124,7 +1124,7 @@ static inline id _getExtraVar(WOComponent *self, NSString *_key) {
     /* only if we have a subclass, we can store values in ivars ... */
     if (![[self->wocVariables objectForKey:_key] isNotNull]) {
       [self debugWithFormat:@"Created component variable (class=%@): '%@'.", 
-	            NSStringFromClass(self->isa), _key];
+	            NSStringFromClass(object_getClass(self)), _key];
     }
   }
 #endif

--- a/sope-appserver/NGObjWeb/WOMailDelivery.m
+++ b/sope-appserver/NGObjWeb/WOMailDelivery.m
@@ -180,7 +180,8 @@ WOMailDelivery *sharedInstance = nil;
       NSData *body;
       
       body = [(NSDictionary *)_email objectForKey:@"body"];
-      if (fwrite([body bytes], [body length], 1, toMail) < 0)
+      NSUInteger bytes = [body length];
+      if (fwrite([body bytes], bytes, 1, toMail) < bytes)
         goto failed;
     }
     fprintf(toMail, "\r\n");

--- a/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.h
+++ b/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.h
@@ -64,7 +64,7 @@
   consume:(BOOL)consume;
 - (BOOL)parseQualifier:(EOQualifier **)result
   from:(unichar **)pos length:(unsigned *)len;
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len;
 
 - (BOOL)parseColumnName:(NSString **)result

--- a/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
@@ -396,7 +396,7 @@ static inline BOOL isTokStopChar(unichar c) {
   return YES;
 }
 
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len
 {
   /* 

--- a/sope-appserver/NGObjWeb/WebDAV/SoObjectDataSource.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoObjectDataSource.m
@@ -137,7 +137,7 @@ static BOOL debugOn = NO;
   pool = [[NSAutoreleasePool alloc] init];
   i=0;
   while ((childKey = [[childKeys nextObject] stringValue]) != nil) {
-    NSDictionary *rec;
+    id rec;
     NSException  *e;
     NSString     *childHref;
     id child = nil;

--- a/sope-appserver/WEExtensions/WETableCalcMatrix.h
+++ b/sope-appserver/WEExtensions/WETableCalcMatrix.h
@@ -66,7 +66,7 @@
   BOOL           rowCheck;
 }
 
-- (id)initWithSize:(unsigned)_width:(unsigned)_height;
+- (id)initWithSize:(unsigned)_width :(unsigned)_height;
 
 /* static accessors */
 
@@ -111,7 +111,7 @@
 
 - (BOOL)tableCalcMatrix:(WETableCalcMatrix *)_matrix
   shouldPlaceObject:(id)_object
-  atPosition:(unsigned)_x:(unsigned)_y;
+  atPosition:(unsigned)_x :(unsigned)_y;
 
 /* define if you want to create own span objects */
 

--- a/sope-appserver/WEExtensions/WETableCalcMatrix.m
+++ b/sope-appserver/WEExtensions/WETableCalcMatrix.m
@@ -356,7 +356,7 @@ static NSNull *null = nil;
   MatrixCoord *positions;
 }
 
-- (void)addPosition:(unsigned)_x:(unsigned)_y;
+- (void)addPosition:(unsigned)_x :(unsigned)_y;
 - (void)checkForDuplicates;
 
 /* narrow set to row or column */
@@ -387,7 +387,7 @@ static NSNull *null = nil;
   }
 }
 
-- (void)addPosition:(unsigned)_x:(unsigned)_y {
+- (void)addPosition:(unsigned)_x :(unsigned)_y {
   if (self->positions == NULL) {
     self->positions = calloc(1, sizeof(MatrixCoord));
     self->positions[0].x = _x;
@@ -468,7 +468,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
          (y * sizeof(MatrixEntry));
 }
 
-- (id)initWithSize:(unsigned)_width:(unsigned)_height {
+- (id)initWithSize:(unsigned)_width :(unsigned)_height {
   if (_width == 0 || _height == 0) {
     [self logWithFormat:@"ERROR: specified invalid matrix dimensions: %ix%i",
             _width, _height];
@@ -572,7 +572,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
   return YES;
 }
 
-- (BOOL)object:(id)_obj matchesCellAt:(unsigned)_x:(unsigned)_y {
+- (BOOL)object:(id)_obj matchesCellAt:(unsigned)_x :(unsigned)_y {
   return [self->delegate tableCalcMatrix:self
                          shouldPlaceObject:_obj
                          atPosition:_x:_y];
@@ -580,7 +580,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
 
 /* adding object to structure */
 
-- (void)addObject:(id)_obj toCellAt:(unsigned)_x:(unsigned)_y {
+- (void)addObject:(id)_obj toCellAt:(unsigned)_x :(unsigned)_y {
   WETableCalcMatrixPositionArray *positions;
   MatrixEntry *e;
   

--- a/sope-appserver/WEExtensions/WETableMatrix.m
+++ b/sope-appserver/WEExtensions/WETableMatrix.m
@@ -139,7 +139,7 @@ static NSNumber *numForUInt(unsigned int i) {
 
 - (BOOL)tableCalcMatrix:(WETableCalcMatrix *)_matrix
   shouldPlaceObject:(id)_object
-  atPosition:(unsigned)_x:(unsigned)_y
+  atPosition:(unsigned)_x :(unsigned)_y
 {
   id   _row, _col;
   BOOL doPlace;

--- a/sope-core/EOControl/EOGlobalID.m
+++ b/sope-core/EOControl/EOGlobalID.m
@@ -95,7 +95,7 @@ static unsigned int   ip;
 }
 
 - (id)init {
-  [self->isa assignGloballyUniqueBytes:&(self->idbuffer[0])];
+  [object_getClass(self) assignGloballyUniqueBytes:&(self->idbuffer[0])];
   return self;
 }
 

--- a/sope-core/EOControl/EOKeyGlobalID.m
+++ b/sope-core/EOControl/EOKeyGlobalID.m
@@ -96,7 +96,7 @@
   if (_other == nil)  return NO;
   if (_other == self) return YES;
   otherKey = _other;
-  if (otherKey->isa   != self->isa)   return NO;
+  if (object_getClass(otherKey)   != object_getClass(self))   return NO;
   if (otherKey->count != self->count) return NO;
   if (![otherKey->entityName isEqualToString:self->entityName]) return NO;
   

--- a/sope-core/EOControl/EOSQLParser.h
+++ b/sope-core/EOControl/EOSQLParser.h
@@ -64,7 +64,7 @@
   consume:(BOOL)consume;
 - (BOOL)parseQualifier:(EOQualifier **)result
   from:(unichar **)pos length:(unsigned *)len;
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len;
 
 - (BOOL)parseColumnName:(NSString **)result

--- a/sope-core/EOControl/EOSQLParser.m
+++ b/sope-core/EOControl/EOSQLParser.m
@@ -404,7 +404,7 @@ static inline BOOL isTokStopChar(unichar c) {
   return YES;
 }
 
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len
 {
   /* 

--- a/sope-core/NGExtensions/FdExt.subproj/NSObject+Logs.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSObject+Logs.m
@@ -52,10 +52,10 @@ static inline Class NSStringClass(void) {
                                          200);
     lm = [NGLoggerManager defaultLoggerManager];
   }
-  logger = NSMapGet(loggerForClassMap, self->isa);
+  logger = NSMapGet(loggerForClassMap, object_getClass(self));
   if (!logger) {
-    logger = [lm loggerForClass:self->isa];
-    NSMapInsert(loggerForClassMap, self->isa, logger);
+    logger = [lm loggerForClass: object_getClass(self)];
+    NSMapInsert(loggerForClassMap, object_getClass(self), logger);
   }
 
   return logger;

--- a/sope-core/NGExtensions/FdExt.subproj/NSSet+enumerator.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSSet+enumerator.m
@@ -21,6 +21,7 @@
 */
 
 #include "NSSet+enumerator.h"
+#include "NSArray+enumerator.h"
 #include "common.h"
 
 @implementation NSSet(enumerator)

--- a/sope-core/NGExtensions/FdExt.subproj/NSString+misc.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSString+misc.m
@@ -21,6 +21,7 @@
 */
 
 #include "NSString+misc.h"
+#include "NSException+misc.h"
 #include "common.h"
 
 @implementation NSObject(StringBindings)

--- a/sope-core/NGExtensions/NGCalendarDateRange.m
+++ b/sope-core/NGExtensions/NGCalendarDateRange.m
@@ -164,7 +164,7 @@
   if (other == self)
     return YES;
   
-  if ([other isKindOfClass:self->isa] == NO)
+  if ([other isKindOfClass: object_getClass(self)] == NO)
     return NO;
   
   return ([self->startDate isEqual:[other startDate]] && 
@@ -194,7 +194,7 @@
   description = [NSMutableString stringWithCapacity:64];
 
   [description appendFormat:@"<%@[0x%p]: startDate:%@ endDate: ", 
-	         NSStringFromClass(self->isa), self, self->startDate];
+	         NSStringFromClass(object_getClass(self)), self, self->startDate];
   
   if ([self->startDate isEqual:self->endDate])
     [description appendString:@"== startDate"];

--- a/sope-core/NGStreams/NGActiveSocket.m
+++ b/sope-core/NGStreams/NGActiveSocket.m
@@ -410,7 +410,7 @@
   if ([self isConnected]) {
     [[[NGSocketAlreadyConnectedException alloc]
               initWithReason:@"Could not connected: socket is already connected"
-              socket:self address:self->remoteAddress] raise];
+              socket:self] raise];
     return NO;
   }
 
@@ -748,10 +748,7 @@
     if ((readResult < 0) && (errno == EINVAL)) {
       NSLog(@"%s: invalid argument in NGDescriptorRecv(%i, 0x%p, %i, %i)",
             __PRETTY_FUNCTION__,
-            self->fd, _buf, _len, 0,
-            (self->receiveTimeout == 0.0)
-            ? -1 // block until data
-            : (int)(self->receiveTimeout * 1000.0));
+            self->fd, _buf, _len, 0);
     }
 #endif
     

--- a/sope-gdl1/GDLAccess/EOAdaptor.m
+++ b/sope-gdl1/GDLAccess/EOAdaptor.m
@@ -31,6 +31,7 @@
 #include "EOFExceptions.h"
 #include "EOModel.h"
 #include "EOSQLExpression.h"
+#include "NGExtensions/NSException+misc.h"
 #include "common.h"
 
 @implementation EOAdaptor

--- a/sope-gdl1/GDLAccess/EODatabaseChannel.m
+++ b/sope-gdl1/GDLAccess/EODatabaseChannel.m
@@ -81,7 +81,7 @@ NSString *EODatabaseChannelDidLockObjectName =
 - (Class)privateClassForEntity:(EOEntity *)anEntity;
 - (void)privateUpdateCurrentEntityInfo;
 - (void)privateClearCurrentEntityInfo;
-- (void)privateReportError:(SEL)method:(NSString *)format, ...;
+- (void)privateReportError:(SEL)method :(NSString *)format, ...;
 @end
 
 /*

--- a/sope-gdl1/GDLAccess/EODatabaseFault.m
+++ b/sope-gdl1/GDLAccess/EODatabaseFault.m
@@ -35,6 +35,7 @@
 #import "EODatabaseFaultResolver.h"
 #import "EOArrayProxy.h"
 #import "common.h"
+#import "NGExtensions/NSException+misc.h"
 
 #if NeXT_RUNTIME || APPLE_RUNTIME
 #  include <objc/objc-class.h>

--- a/sope-gdl1/GDLAccess/EODatabaseFault.m
+++ b/sope-gdl1/GDLAccess/EODatabaseFault.m
@@ -85,8 +85,8 @@ typedef struct {
     }
     fault->faultResolver = [[EOObjectFault alloc] initWithPrimaryKey:key
         entity:entity databaseChannel:channel zone:zone 
-        targetClass:fault->isa];
-    fault->isa = self;
+        targetClass:object_getClass(fault)];
+    object_setClass(fault, self);
     
     return (EODatabaseFault *)AUTORELEASE(fault);
 }
@@ -151,8 +151,8 @@ typedef struct {
   }
   fault->faultResolver = [[EOArrayFault alloc] initWithQualifier:qualifier
         fetchOrder:fetchOrder databaseChannel:channel zone:zone 
-        targetClass:fault->isa];
-  fault->isa = self;
+        targetClass:object_getClass(fault)];
+  object_setClass(fault, self);
 
   return (NSArray *)AUTORELEASE(fault);
 }
@@ -161,7 +161,7 @@ typedef struct {
   EODatabaseFault *aFault = (EODatabaseFault *)fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
     
   return [(EODatabaseFaultResolver *)aFault->faultResolver primaryKey];
@@ -171,7 +171,7 @@ typedef struct {
   EODatabaseFault *aFault = (EODatabaseFault *)fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
 
   return [(EODatabaseFaultResolver *)aFault->faultResolver entity];
@@ -181,7 +181,7 @@ typedef struct {
   EODatabaseFault *aFault = (EODatabaseFault *)fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
     
   return [(EODatabaseFaultResolver *)aFault->faultResolver qualifier];
@@ -191,7 +191,7 @@ typedef struct {
   EODatabaseFault *aFault = (EODatabaseFault *)fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
     
   return [(EODatabaseFaultResolver *)aFault->faultResolver fetchOrder];
@@ -201,7 +201,7 @@ typedef struct {
   EODatabaseFault *aFault = (EODatabaseFault *)fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
     
   return [(EODatabaseFaultResolver *)aFault->faultResolver databaseChannel];

--- a/sope-gdl1/GDLAccess/EOFExceptions.m
+++ b/sope-gdl1/GDLAccess/EOFExceptions.m
@@ -63,7 +63,7 @@
                             [destinationEntity name],
                             definition,
                             [relationship name]];
-    [self initWithName:NSStringFromClass(isa)
+    [self initWithName:NSStringFromClass(object_getClass(self))
             reason:_reason userInfo:nil];
     return self;
 }
@@ -74,7 +74,7 @@
 - initWithName:(NSString*)_name
 {
     id _reason = [NSString stringWithFormat:@"invalid name: '%@'", _name];
-    [self initWithName:NSStringFromClass(isa) reason:_reason userInfo:nil];
+    [self initWithName:NSStringFromClass(object_getClass(self)) reason:_reason userInfo:nil];
     return self;
 }
 @end /* InvalidNameException */
@@ -86,7 +86,7 @@
     id _reason = [NSString stringWithFormat:@"property '%@' does not exist in "
                             @"entity '%@'", propertyName,
                             [(EOEntity*)currentEntity name]];
-    [self initWithName:NSStringFromClass(isa)
+    [self initWithName:NSStringFromClass(object_getClass(self))
             reason:_reason userInfo:nil];
     return self;
 }
@@ -99,7 +99,7 @@
     id _reason = [NSString stringWithFormat:@"property '%@' must be to one in "
                     @"entity '%@' to allow flattened attribute",
                     propertyName, [(EOEntity*)currentEntity name]];
-    [self initWithName:NSStringFromClass(isa)
+    [self initWithName:NSStringFromClass(object_getClass(self))
             reason:_reason userInfo:nil];
     return self;
 }

--- a/sope-gdl1/GDLAccess/EOFault.m
+++ b/sope-gdl1/GDLAccess/EOFault.m
@@ -67,7 +67,7 @@ typedef struct objc_method      *Method_t;
 + (void)makeObjectIntoFault:(id)_object withHandler:(EOFaultHandler *)_handler{
   [_handler setTargetClass:[_object class] extraData:((id *)_object)[1]];
 
-  ((EOFault *)_object)->isa           = self;
+  object_setClass(_object, self);
   ((EOFault *)_object)->faultResolver = [_handler retain];
 }
 
@@ -85,14 +85,14 @@ typedef struct objc_method      *Method_t;
   int refs;
 
   /* check if fault */
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return;
     
   /* get fault instance reference count + 1 set in creation methods */
   refs = aFault->faultResolver->faultReferences;
 
   /* make clear instance */
-  aFault->isa           = [aFault->faultResolver targetClass];
+  object_setClass(aFault, [aFault->faultResolver targetClass]);
   aFault->faultResolver = [aFault->faultResolver autorelease];
   aFault->faultResolver = [aFault->faultResolver extraData];
   
@@ -112,7 +112,7 @@ typedef struct objc_method      *Method_t;
   if (EOFaultClass == Nil) EOFaultClass = [EOFault class];
 
 #if defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) || (__GNU_LIBOBJC__ >= 20100911)
-  for (clazz = ((EOFault *)fault)->isa; clazz; clazz = class_getSuperclass(clazz)) {
+  for (clazz = object_getClass(fault); clazz; clazz = class_getSuperclass(clazz)) {
 #else
   for (clazz = ((EOFault *)fault)->isa; clazz; clazz = clazz->super_class) {
 #endif
@@ -132,7 +132,7 @@ typedef struct objc_method      *Method_t;
   EOFault *aFault = (EOFault*)_fault;
 
   // Check that argument is fault
-  if (aFault->isa != self)
+  if (object_getClass(aFault) != self)
     return nil;
     
   return [aFault->faultResolver targetClass];
@@ -182,7 +182,7 @@ typedef struct objc_method      *Method_t;
 #if GNU_RUNTIME
   return (object_is_instance(self))
     ? [self->faultResolver respondsToSelector:_selector forFault:self]
-    : class_get_class_method(self->isa, _selector) != METHOD_NULL;
+    : class_get_class_method(object_getClass(self), _selector) != METHOD_NULL;
 #else
 #  warning TODO: add complete implementation for Apple/NeXT runtime!
   return [self->faultResolver respondsToSelector:_selector forFault:self];
@@ -239,7 +239,7 @@ typedef struct objc_method      *Method_t;
   NSLog(@"WARNING: tried to deallocate EOFault class ..");
 }
 - (void)dealloc {
-  [self->isa clearFault:self];
+  [object_getClass(self) clearFault:self];
   [self dealloc];
 }
 
@@ -285,7 +285,7 @@ static inline void _resolveFault(EOFault *self) {
   handler = self->faultResolver;
   [handler completeInitializationOfObject:self];
   
-  if (self->isa == [EOFault class]) {
+  if (object_getClass(self) == [EOFault class]) {
     [NSException raise:@"NSInvalidArgumentException" 
 		 format:
 		   @"fault error: %@ was not cleared during fault fetching",

--- a/sope-gdl1/GDLAccess/EOModel.m
+++ b/sope-gdl1/GDLAccess/EOModel.m
@@ -255,7 +255,7 @@ void EOModel_linkCategories(void) {
   NSMutableDictionary *model = [NSMutableDictionary dictionaryWithCapacity:64];
   int i, count;
     
-  [model setObject:[[NSNumber numberWithInt:[isa version]] stringValue]
+  [model setObject:[[NSNumber numberWithInt:[object_getClass(self) version]] stringValue]
 	 forKey:@"EOModelVersion"];
   if (name)
         [model setObject:name forKey:@"name"];

--- a/sope-gdl1/GDLAccess/EOPrimaryKeyDictionary.m
+++ b/sope-gdl1/GDLAccess/EOPrimaryKeyDictionary.m
@@ -130,7 +130,7 @@
 - (BOOL)isEqualToDictionary:(NSDictionary *)other {
     if (self == (EOSinglePrimaryKeyDictionary*)other)
         return YES;
-    if (self->isa == ((EOSinglePrimaryKeyDictionary*)other)->isa) {
+    if (object_getClass(self) == object_getClass(other)) {
         if (fastHash == ((EOSinglePrimaryKeyDictionary*)other)->fastHash &&
             [key isEqual:((EOSinglePrimaryKeyDictionary*)other)->key] &&
             [value isEqual:((EOSinglePrimaryKeyDictionary*)other)->value])
@@ -157,7 +157,7 @@
 - (BOOL)fastIsEqual:(id)other {
     if (self == other)
         return YES;
-    if (self->isa == ((EOSinglePrimaryKeyDictionary*)other)->isa) {
+    if (object_getClass(self) == object_getClass(other)) {
         if (fastHash == ((EOSinglePrimaryKeyDictionary*)other)->fastHash &&
             key == ((EOSinglePrimaryKeyDictionary*)other)->key &&
             [value isEqual:((EOSinglePrimaryKeyDictionary*)other)->value])
@@ -316,7 +316,7 @@
 - (BOOL)fastIsEqual:(id)aDict {
     int i;
     
-    if (self->isa != ((EOMultiplePrimaryKeyDictionary*)aDict)->isa) {
+    if (object_getClass(self) == object_getClass(aDict)) {
       [NSException raise:NSInvalidArgumentException
 		   format:@"fastIsEqual: can compare only "
                            @"EOPrimaryKeyDictionary instances"];

--- a/sope-gdl1/GDLAccess/EOSQLExpression.m
+++ b/sope-gdl1/GDLAccess/EOSQLExpression.m
@@ -39,6 +39,7 @@
 #include <EOControl/EONull.h>
 #include <EOControl/EOQualifier.h>
 #include <EOControl/EOSortOrdering.h>
+#import "NGExtensions/NSException+misc.h"
 
 #if LIB_FOUNDATION_LIBRARY
 #  include <extensions/DefaultScannerHandler.h>

--- a/sope-gdl1/GDLAccess/EOSQLQualifier.m
+++ b/sope-gdl1/GDLAccess/EOSQLQualifier.m
@@ -39,6 +39,7 @@
 #include <EOControl/EOKeyValueCoding.h>
 #include <EOControl/EONull.h>
 #import "EOQualifierScanner.h"
+#import "NGExtensions/NSException+misc.h"
 
 #if LIB_FOUNDATION_LIBRARY
 #  include <extensions/DefaultScannerHandler.h>

--- a/sope-gdl1/GDLAccess/EOSQLQualifier.m
+++ b/sope-gdl1/GDLAccess/EOSQLQualifier.m
@@ -468,7 +468,7 @@ handle_attribute(EOSQLQualifier *self, id object, id _relationshipPaths)
 - (id)copyWithZone:(NSZone*)zone {
   EOSQLQualifier* copy = nil;
 
-  copy                    = [[self->isa allocWithZone:zone] init];
+  copy                    = [[object_getClass(self) allocWithZone:zone] init];
   copy->entity            = RETAIN(self->entity);
   copy->content           = [self->content           mutableCopyWithZone:zone];
   copy->relationshipPaths = [self->relationshipPaths mutableCopyWithZone:zone];

--- a/sope-gdl1/PostgreSQL/NSString+PostgreSQL72.m
+++ b/sope-gdl1/PostgreSQL/NSString+PostgreSQL72.m
@@ -145,12 +145,14 @@ static NSCharacterSet *spaceSet = nil;
   range.length = 0;
 
   for (range.location = ([self length] - 1);
-         range.location >= 0;
-         range.location++, range.length++) {
+         ;
+         range.location--, range.length++) {
       unichar c;
       
       c = charAtIndex(self, @selector(characterAtIndex:), range.location);
       if (![spaceSet characterIsMember:c])
+        break;
+      if (range.location == 0)
         break;
   }
     

--- a/sope-mime/NGImap4/NGImap4Client.h
+++ b/sope-mime/NGImap4/NGImap4Client.h
@@ -195,6 +195,14 @@ typedef enum {
   qualifierString:(NSString *)_qualString
   encoding:(NSString *)_encoding;
 
+/* Previously in Private category, but required by SoObjects/Mailer/SOGoMailBaseObject.m */
+
+- (NGHashMap *)processCommand:(NSString *)_command;
+- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag;
+- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag
+  withNotification:(BOOL)_notification;
+- (NGHashMap *)processCommand:(NSString *)_command logText:(NSString *)_txt;
+
 @end
 
 #endif /* __SOPE_NGImap4_NGImap4Client_H__ */

--- a/sope-mime/NGImap4/NGImap4Client.m
+++ b/sope-mime/NGImap4/NGImap4Client.m
@@ -77,12 +77,6 @@
 
 - (NSString *)_folder2ImapFolder:(NSString *)_folder;
 
-- (NGHashMap *)processCommand:(NSString *)_command;
-- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag;
-- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag
-  withNotification:(BOOL)_notification;
-- (NGHashMap *)processCommand:(NSString *)_command logText:(NSString *)_txt;
-
 - (void)sendCommand:(NSString *)_command;
 - (void)sendCommand:(NSString *)_command withTag:(BOOL)_tag;
 - (void)sendCommand:(NSString *)_command withTag:(BOOL)_tag

--- a/sope-mime/NGImap4/NGImap4Context.m
+++ b/sope-mime/NGImap4/NGImap4Context.m
@@ -944,8 +944,7 @@ static int ImapLogEnabled                           = -1;
         [self serverName],
         [self serverKind],
         [self serverVersion],
-        [self serverSubVersion],
-        [self serverTag]];
+        [self serverSubVersion]];
   
   if (self->syncMode)
     [ms appendString:@" syncmode"];

--- a/sope-mime/NGImap4/NGImap4Folder.m
+++ b/sope-mime/NGImap4/NGImap4Folder.m
@@ -646,11 +646,11 @@ static int FetchNewUnseenMessagesInSubFoldersOnDemand = -1;
       [m release];
     }
   }
-  m = [mes copy];
+  NSArray *a = [mes copy];
   [mes release]; mes = nil;
   [pool release];
   
-  return [m autorelease];;
+  return [a autorelease];;
 }
 
 - (NSArray *)_buildMessagesFromFetch:(NSDictionary *)_fetch {

--- a/sope-mime/NGMime/NGMimePartGenerator.h
+++ b/sope-mime/NGMime/NGMimePartGenerator.h
@@ -149,7 +149,7 @@
   The delegate can select which NGMimeBodyGenerator should de used
   for generate the given part.
 */  
-- (id<NGMimePartGenerator>)multipartBodyGenerator:(id<NGMimeBodyGenerator>)
+- (id<NGMimePartGenerator>)multipartBodyGenerator:(id<NGMimeBodyGenerator>)aGenerator
   generatorForPart:(id<NGMimePart>)_part;
 
 - (BOOL)useMimeData;

--- a/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldGenerator.m
+++ b/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldGenerator.m
@@ -47,7 +47,7 @@
 #else
     dateString = [date descriptionWithCalendarFormat: @" %a, %d %b %Y %H:%M:%S %z"
                                             timeZone: [NSTimeZone timeZoneWithName: @"GMT"]
-                                              locale: [[[NSLocale alloc] initWithLocaleIdentifier: @"en_US"] autorelease]];
+                                              locale: (NSDictionary *)[[[NSLocale alloc] initWithLocaleIdentifier: @"en_US"] autorelease]];
 #endif
   }
   else

--- a/sope-xml/SaxObjC/SaxObjectDecoder.m
+++ b/sope-xml/SaxObjC/SaxObjectDecoder.m
@@ -172,7 +172,7 @@ static NSNull *null = nil;
 		      reason:_ns
 		      userInfo:nil];
 }
-- (NSException *)missingElementMapping:(NSString *)_ns:(NSString *)_tag {
+- (NSException *)missingElementMapping:(NSString *)_ns :(NSString *)_tag {
   return [NSException exceptionWithName:@"MissingElementMapping"
 		      reason:_tag
 		      userInfo:nil];


### PR DESCRIPTION
Stage 2:
These fix method declaration syntax issues. Mostly by adding a spaces after the parameter names to remove ambiguity from the next parameter(s).

Stage 3: ***CAUTION***
These fix deprecated 'isa' calls by using object_getClass and object_setClass. This may cause problem with older compilers/objc libraries.

Stage 4:
Various code cleanup and fixes. Mostly made by David Chisnall from patches that date back to Oct 2013.

Stage 5:
Missing header file imports. Some of these are needed to clear warnings in SOGo too.

Stage 6:
Fix hidden method (processCommand) in NGImap4Client.m required by SOGo (SoObjects/Mailer/SOGoMailBaseObject.m).