### PR TITLE
Stage 2 of clang compiler warning patches. Function declaration synta…

### DIFF
--- a/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.h
+++ b/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.h
@@ -101,7 +101,7 @@
 - (BOOL)hasDefaultAccessDeclaration;
 - (void)declarePublic:(NSString *)_firstName, ...;
 - (void)declarePrivate:(NSString *)_firstName, ...;
-- (void)declareProtected:(NSString *)_perm:(NSString *)_firstName, ...;
+- (void)declareProtected:(NSString *)_perm :(NSString *)_firstName, ...;
 
 /* object security */
 

--- a/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoClassSecurityInfo.m
@@ -111,7 +111,7 @@
   va_end(va);
 }
 
-- (void)declareProtected:(NSString *)_perm:(NSString *)_firstName, ... {
+- (void)declareProtected:(NSString *)_perm :(NSString *)_firstName, ... {
   va_list  va;
   NSString *aname;
 

--- a/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.h
+++ b/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.h
@@ -64,7 +64,7 @@
   consume:(BOOL)consume;
 - (BOOL)parseQualifier:(EOQualifier **)result
   from:(unichar **)pos length:(unsigned *)len;
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len;
 
 - (BOOL)parseColumnName:(NSString **)result

--- a/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
+++ b/sope-appserver/NGObjWeb/WebDAV/SoDAVSQLParser.m
@@ -396,7 +396,7 @@ static inline BOOL isTokStopChar(unichar c) {
   return YES;
 }
 
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len
 {
   /* 

--- a/sope-appserver/WEExtensions/WETableCalcMatrix.h
+++ b/sope-appserver/WEExtensions/WETableCalcMatrix.h
@@ -66,7 +66,7 @@
   BOOL           rowCheck;
 }
 
-- (id)initWithSize:(unsigned)_width:(unsigned)_height;
+- (id)initWithSize:(unsigned)_width :(unsigned)_height;
 
 /* static accessors */
 
@@ -111,7 +111,7 @@
 
 - (BOOL)tableCalcMatrix:(WETableCalcMatrix *)_matrix
   shouldPlaceObject:(id)_object
-  atPosition:(unsigned)_x:(unsigned)_y;
+  atPosition:(unsigned)_x :(unsigned)_y;
 
 /* define if you want to create own span objects */
 

--- a/sope-appserver/WEExtensions/WETableCalcMatrix.m
+++ b/sope-appserver/WEExtensions/WETableCalcMatrix.m
@@ -356,7 +356,7 @@ static NSNull *null = nil;
   MatrixCoord *positions;
 }
 
-- (void)addPosition:(unsigned)_x:(unsigned)_y;
+- (void)addPosition:(unsigned)_x :(unsigned)_y;
 - (void)checkForDuplicates;
 
 /* narrow set to row or column */
@@ -387,7 +387,7 @@ static NSNull *null = nil;
   }
 }
 
-- (void)addPosition:(unsigned)_x:(unsigned)_y {
+- (void)addPosition:(unsigned)_x :(unsigned)_y {
   if (self->positions == NULL) {
     self->positions = calloc(1, sizeof(MatrixCoord));
     self->positions[0].x = _x;
@@ -468,7 +468,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
          (y * sizeof(MatrixEntry));
 }
 
-- (id)initWithSize:(unsigned)_width:(unsigned)_height {
+- (id)initWithSize:(unsigned)_width :(unsigned)_height {
   if (_width == 0 || _height == 0) {
     [self logWithFormat:@"ERROR: specified invalid matrix dimensions: %ix%i",
             _width, _height];
@@ -572,7 +572,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
   return YES;
 }
 
-- (BOOL)object:(id)_obj matchesCellAt:(unsigned)_x:(unsigned)_y {
+- (BOOL)object:(id)_obj matchesCellAt:(unsigned)_x :(unsigned)_y {
   return [self->delegate tableCalcMatrix:self
                          shouldPlaceObject:_obj
                          atPosition:_x:_y];
@@ -580,7 +580,7 @@ static inline MatrixEntry *entryAt(WETableCalcMatrix *self, unsigned x,
 
 /* adding object to structure */
 
-- (void)addObject:(id)_obj toCellAt:(unsigned)_x:(unsigned)_y {
+- (void)addObject:(id)_obj toCellAt:(unsigned)_x :(unsigned)_y {
   WETableCalcMatrixPositionArray *positions;
   MatrixEntry *e;
   

--- a/sope-appserver/WEExtensions/WETableMatrix.m
+++ b/sope-appserver/WEExtensions/WETableMatrix.m
@@ -139,7 +139,7 @@ static NSNumber *numForUInt(unsigned int i) {
 
 - (BOOL)tableCalcMatrix:(WETableCalcMatrix *)_matrix
   shouldPlaceObject:(id)_object
-  atPosition:(unsigned)_x:(unsigned)_y
+  atPosition:(unsigned)_x :(unsigned)_y
 {
   id   _row, _col;
   BOOL doPlace;

--- a/sope-core/EOControl/EOSQLParser.h
+++ b/sope-core/EOControl/EOSQLParser.h
@@ -64,7 +64,7 @@
   consume:(BOOL)consume;
 - (BOOL)parseQualifier:(EOQualifier **)result
   from:(unichar **)pos length:(unsigned *)len;
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len;
 
 - (BOOL)parseColumnName:(NSString **)result

--- a/sope-core/EOControl/EOSQLParser.m
+++ b/sope-core/EOControl/EOSQLParser.m
@@ -404,7 +404,7 @@ static inline BOOL isTokStopChar(unichar c) {
   return YES;
 }
 
-- (BOOL)parseScope:(NSString **)_scope:(NSString **)_entity
+- (BOOL)parseScope:(NSString **)_scope :(NSString **)_entity
   from:(unichar **)pos length:(unsigned *)len
 {
   /* 

--- a/sope-gdl1/GDLAccess/EODatabaseChannel.m
+++ b/sope-gdl1/GDLAccess/EODatabaseChannel.m
@@ -81,7 +81,7 @@ NSString *EODatabaseChannelDidLockObjectName =
 - (Class)privateClassForEntity:(EOEntity *)anEntity;
 - (void)privateUpdateCurrentEntityInfo;
 - (void)privateClearCurrentEntityInfo;
-- (void)privateReportError:(SEL)method:(NSString *)format, ...;
+- (void)privateReportError:(SEL)method :(NSString *)format, ...;
 @end
 
 /*

--- a/sope-mime/NGMime/NGMimePartGenerator.h
+++ b/sope-mime/NGMime/NGMimePartGenerator.h
@@ -149,7 +149,7 @@
   The delegate can select which NGMimeBodyGenerator should de used
   for generate the given part.
 */  
-- (id<NGMimePartGenerator>)multipartBodyGenerator:(id<NGMimeBodyGenerator>)
+- (id<NGMimePartGenerator>)multipartBodyGenerator:(id<NGMimeBodyGenerator>)aGenerator
   generatorForPart:(id<NGMimePart>)_part;
 
 - (BOOL)useMimeData;

--- a/sope-xml/SaxObjC/SaxObjectDecoder.m
+++ b/sope-xml/SaxObjC/SaxObjectDecoder.m
@@ -172,7 +172,7 @@ static NSNull *null = nil;
 		      reason:_ns
 		      userInfo:nil];
 }
-- (NSException *)missingElementMapping:(NSString *)_ns:(NSString *)_tag {
+- (NSException *)missingElementMapping:(NSString *)_ns :(NSString *)_tag {
   return [NSException exceptionWithName:@"MissingElementMapping"
 		      reason:_tag
 		      userInfo:nil];


### PR DESCRIPTION
…x fixes.

Stage 2:
These fix method declaration syntax issues. Mostly by adding a spaces after the parameter names to remove ambiguity from the next parameter(s).