### PR TITLE
Stage 5 of clang compiler warning patches. Missing header file imports.

### DIFF
--- a/sope-core/NGExtensions/FdExt.subproj/NSSet+enumerator.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSSet+enumerator.m
@@ -21,6 +21,7 @@
 */
 
 #include "NSSet+enumerator.h"
+#include "NSArray+enumerator.h"
 #include "common.h"
 
 @implementation NSSet(enumerator)

--- a/sope-core/NGExtensions/FdExt.subproj/NSString+misc.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSString+misc.m
@@ -21,6 +21,7 @@
 */
 
 #include "NSString+misc.h"
+#include "NSException+misc.h"
 #include "common.h"
 
 @implementation NSObject(StringBindings)

--- a/sope-gdl1/GDLAccess/EOAdaptor.m
+++ b/sope-gdl1/GDLAccess/EOAdaptor.m
@@ -31,6 +31,7 @@
 #include "EOFExceptions.h"
 #include "EOModel.h"
 #include "EOSQLExpression.h"
+#include "NGExtensions/NSException+misc.h"
 #include "common.h"
 
 @implementation EOAdaptor

--- a/sope-gdl1/GDLAccess/EODatabaseFault.m
+++ b/sope-gdl1/GDLAccess/EODatabaseFault.m
@@ -35,6 +35,7 @@
 #import "EODatabaseFaultResolver.h"
 #import "EOArrayProxy.h"
 #import "common.h"
+#import "NGExtensions/NSException+misc.h"
 
 #if NeXT_RUNTIME || APPLE_RUNTIME
 #  include <objc/objc-class.h>

--- a/sope-gdl1/GDLAccess/EOSQLExpression.m
+++ b/sope-gdl1/GDLAccess/EOSQLExpression.m
@@ -39,6 +39,7 @@
 #include <EOControl/EONull.h>
 #include <EOControl/EOQualifier.h>
 #include <EOControl/EOSortOrdering.h>
+#import "NGExtensions/NSException+misc.h"
 
 #if LIB_FOUNDATION_LIBRARY
 #  include <extensions/DefaultScannerHandler.h>

--- a/sope-gdl1/GDLAccess/EOSQLQualifier.m
+++ b/sope-gdl1/GDLAccess/EOSQLQualifier.m
@@ -39,6 +39,7 @@
 #include <EOControl/EOKeyValueCoding.h>
 #include <EOControl/EONull.h>
 #import "EOQualifierScanner.h"
+#import "NGExtensions/NSException+misc.h"
 
 #if LIB_FOUNDATION_LIBRARY
 #  include <extensions/DefaultScannerHandler.h>


### PR DESCRIPTION
Stage 5:
Missing header file imports. Some of these are needed to clear warnings in SOGo too.