### PR TITLE
Stage 6 of clang compiler warning patches. Fix hidden method in NGIma…

### DIFF
--- a/sope-mime/NGImap4/NGImap4Client.h
+++ b/sope-mime/NGImap4/NGImap4Client.h
@@ -195,6 +195,14 @@ typedef enum {
   qualifierString:(NSString *)_qualString
   encoding:(NSString *)_encoding;
 
+/* Previously in Private category, but required by SoObjects/Mailer/SOGoMailBaseObject.m */
+
+- (NGHashMap *)processCommand:(NSString *)_command;
+- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag;
+- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag
+  withNotification:(BOOL)_notification;
+- (NGHashMap *)processCommand:(NSString *)_command logText:(NSString *)_txt;
+
 @end
 
 #endif /* __SOPE_NGImap4_NGImap4Client_H__ */

--- a/sope-mime/NGImap4/NGImap4Client.m
+++ b/sope-mime/NGImap4/NGImap4Client.m
@@ -77,12 +77,6 @@
 
 - (NSString *)_folder2ImapFolder:(NSString *)_folder;
 
-- (NGHashMap *)processCommand:(NSString *)_command;
-- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag;
-- (NGHashMap *)processCommand:(NSString *)_command withTag:(BOOL)_tag
-  withNotification:(BOOL)_notification;
-- (NGHashMap *)processCommand:(NSString *)_command logText:(NSString *)_txt;
-
 - (void)sendCommand:(NSString *)_command;
 - (void)sendCommand:(NSString *)_command withTag:(BOOL)_tag;
 - (void)sendCommand:(NSString *)_command withTag:(BOOL)_tag


### PR DESCRIPTION
…p4Client.m required by SOGo.

Stage 6:
Fix hidden method (processCommand) in NGImap4Client.m required by SOGo (SoObjects/Mailer/SOGoMailBaseObject.m).