### PR TITLE
Stage 7 of clang compiler warning patches.

### DIFF
--- a/sope-core/NGStreams/NGActiveSocket.m
+++ b/sope-core/NGStreams/NGActiveSocket.m
@@ -19,6 +19,7 @@
   02111-1307, USA.
 */
 
+#include <sys/types.h>
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 

--- a/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldGenerator.m
+++ b/sope-mime/NGMime/NGMimeRFC822DateHeaderFieldGenerator.m
@@ -47,7 +47,7 @@
 #else
     dateString = [date descriptionWithCalendarFormat: @" %a, %d %b %Y %H:%M:%S %z"
                                             timeZone: [NSTimeZone timeZoneWithName: @"GMT"]
-                                              locale: [[[NSLocale alloc] initWithLocaleIdentifier: @"en_US"] autorelease]];
+                                              locale: (NSDictionary *)[[[NSLocale alloc] initWithLocaleIdentifier: @"en_US"] autorelease]];
 #endif
   }
   else


### PR DESCRIPTION
1.) Cast NSLocale* to NSDictionary* when sending to [NSCalendarDate descriptionWithCalendarFormat]

2.) Add missing include of sys/types.h which causes a build error on FreeBSD.