### PR TITLE
Stage 8 of clang compiler warning patches.

### DIFF
--- a/sope-appserver/NGObjWeb/Associations/WOKeyPathAssociation.m
+++ b/sope-appserver/NGObjWeb/Associations/WOKeyPathAssociation.m
@@ -30,7 +30,6 @@
 #define object_is_instance(XXX) (XXX != nil)
 #define class_get_class_method    class_getClassMethod
 #define class_get_instance_method class_getInstanceMethod
-#define sel_get_uid               sel_getUid
 #define method_get_imp			  method_getImplementation	
 typedef struct objc_method      *Method_t;
 
@@ -48,7 +47,6 @@ typedef struct objc_method      *Method_t;
 
 #define method_get_imp            method_getImplementation  
 #  define METHOD_NULL NULL
-#  define sel_get_uid               sel_getUid
 #  define class_get_class_method    class_getClassMethod
 #  define class_get_instance_method class_getInstanceMethod
 
@@ -430,14 +428,14 @@ static inline void _fillInfo(WOKeyPathAssociation *self, id object,
 		[[StringClass alloc] initWithCString:(char *)info->ckey];
             }
             else {
-              info->extra.sel.get = sel_get_uid((char *)info->ckey);
+              info->extra.sel.get = sel_registerName((char *)info->ckey);
               method = class_get_instance_method(clazz, info->extra.sel.get);
               if (method != METHOD_NULL)
                 info->type = WOKeyType_method;
             }
           }
           else {
-            info->extra.sel.get = sel_get_uid((char *)info->ckey);
+            info->extra.sel.get = sel_registerName((char *)info->ckey);
             method = class_get_instance_method(clazz, info->extra.sel.get);
             
             if (method != METHOD_NULL)
@@ -461,7 +459,7 @@ static inline void _fillInfo(WOKeyPathAssociation *self, id object,
 	      [[StringClass alloc] initWithCString:(char *)info->ckey];
           }
           else {
-            info->extra.sel.get = sel_get_uid((char *)info->ckey);
+            info->extra.sel.get = sel_registerName((char *)info->ckey);
             method =
               class_get_class_method(*(Class *)object, info->extra.sel.get);
             if (method != METHOD_NULL) {
@@ -807,7 +805,7 @@ static inline SEL _getSetSel(register const unsigned char *_key,
                              register unsigned _len) {
   unsigned char buf[259];
   _getSetSelName(buf, _key, _len);
-  return sel_get_uid((char *)buf);
+  return sel_registerName((char *)buf);
 }
 
 static BOOL _setValue(WOKeyPathAssociation *self, id _value, id root) {

--- a/sope-appserver/NGObjWeb/DynamicElements/WOComponentContent.m
+++ b/sope-appserver/NGObjWeb/DynamicElements/WOComponentContent.m
@@ -75,11 +75,7 @@ static Class NSDateClass = Nil;
         printf("  ");
       printf("content: [%s %s]: %0.3fs\n",
              [[component name] cString], 
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
 	     sel_getName(_cmd), 
-#else
-	     sel_get_name(_cmd), 
-#endif
 	     diff);
     }
     
@@ -115,11 +111,7 @@ static Class NSDateClass = Nil;
         printf("  ");
       printf("content: [%s %s]: %0.3fs\n",
              [[component name] cString], 
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
 	     sel_getName(_cmd), 
-#else
-	     sel_get_name(_cmd), 
-#endif
 	     diff);
     }
     
@@ -165,11 +157,7 @@ static Class NSDateClass = Nil;
         printf("  ");
       printf("content: [%s %s]: %0.3fs\n",
              [[component name] cString], 
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
 	     sel_getName(_cmd), 
-#else
-	     sel_get_name(_cmd), 
-#endif
 	     diff);
     }
     

--- a/sope-appserver/NGObjWeb/DynamicElements/WOComponentReference.m
+++ b/sope-appserver/NGObjWeb/DynamicElements/WOComponentReference.m
@@ -172,11 +172,7 @@ _updateComponent(WOComponentReference *self, WOContext *_ctx)
         printf("  ");
       printf("[%s %s]: %0.3fs\n",
              [[child name] cString], 
-#if APPLE_RUNTIME || NeXT_RUNTIME || (__GNU_LIBOBJC__ >= 20100911)
 	     sel_getName(_cmd), 
-#else
-	     sel_get_name(_cmd), 
-#endif
 	     diff);
     }
   }

--- a/sope-appserver/NGObjWeb/NSObject+WO.m
+++ b/sope-appserver/NGObjWeb/NSObject+WO.m
@@ -131,11 +131,7 @@ static inline SEL _getSetSel(register const unsigned char *_key,
                              register unsigned _len) {
   char buf[259];
   _getSetSelName((unsigned char *)buf, _key, _len);
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
-  return sel_getUid(buf);
-#else
-  return sel_get_uid(buf);
-#endif
+  return sel_registerName(buf);
 }
 
 typedef union {
@@ -267,7 +263,7 @@ IMP WOGetKVCGetMethod(id object, NSString *_key) {
     keyLen = [_key cStringLength];
     buf = malloc(keyLen + 1);
     [_key getCString:buf]; buf[keyLen] = '\0';
-    getSel = sel_get_uid(buf);
+    getSel = sel_registerName(buf);
     free(buf);
 
     if (getSel == NULL) // no such selector
@@ -308,11 +304,7 @@ id WOGetKVCValueUsingMethod(id object, NSString *_key) {
     char *buf;
     buf = malloc(keyLen + 1);
     [_key getCString:buf];
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
-    getSel = sel_getUid(buf);
-#else
-    getSel = sel_get_uid(buf);
-#endif
+    getSel = sel_registerName(buf);
     if (getSel == NULL) // no such selector
       return nil;
     free(buf); buf = NULL;

--- a/sope-appserver/NGObjWeb/SoObjects/SoSelectorInvocation.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoSelectorInvocation.m
@@ -28,11 +28,6 @@
 #include <DOM/EDOM.h>
 #include "common.h"
 
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__)
-#  define sel_get_any_uid   sel_getUid
-#  define sel_register_name sel_registerName
-#endif
-
 @implementation SoSelectorInvocation
 
 static BOOL debugOn = NO;
@@ -109,8 +104,7 @@ static BOOL debugOn = NO;
     /* this can happen if the product bundle is not yet loaded ... */
 #if GNU_RUNTIME
     const char *sname = [_name cString];
-    if ((self->sel = sel_get_any_uid(sname)) == NULL)
-      self->sel = sel_register_name(sname);
+    self->sel = sel_registerName(sname);
 #else
     /* TODO: not tested against this ObjC runtime */
     [self warnWithFormat:@"(%s): not tested against this ObjC runtime, "

--- a/sope-appserver/NGObjWeb/WOChildComponentReference.m
+++ b/sope-appserver/NGObjWeb/WOChildComponentReference.m
@@ -110,7 +110,7 @@ static Class NSDateClass = Nil;
     for (i = [_ctx componentStackCount]; i >= 0; i--)
       printf("  ");
     printf("[%s %s]: %0.3fs\n",
-           [[child name] cString], sel_get_name(_cmd), diff);
+           [[child name] cString], sel_getName(_cmd), diff);
   }
 }
 
@@ -147,7 +147,7 @@ static Class NSDateClass = Nil;
     for (i = [_ctx componentStackCount]; i >= 0; i--)
       printf("  ");
     printf("[%s %s]: %0.3fs\n",
-           [[child name] cString], sel_get_name(_cmd), diff);
+           [[child name] cString], sel_getName(_cmd), diff);
   }
 
   return result;
@@ -188,7 +188,7 @@ static Class NSDateClass = Nil;
     for (i = [_ctx componentStackCount]; i >= 0; i--)
       printf("  ");
     printf("[%s %s]: %0.3fs\n",
-           [[child name] cString], sel_get_name(_cmd), diff);
+           [[child name] cString], sel_getName(_cmd), diff);
   }
 }
 

--- a/sope-appserver/NGObjWeb/WORunLoop.m
+++ b/sope-appserver/NGObjWeb/WORunLoop.m
@@ -255,7 +255,7 @@ static char *activityDesc[8] = {
 {
     return [target isEqual:anotherHolder->target]
 	    && [argument isEqual:anotherHolder->argument]
-	    && SEL_EQ(action, anotherHolder->action);
+	    && sel_isEqual(action, anotherHolder->action);
 }
 
 - (void)execute

--- a/sope-appserver/NGObjWeb/WOSession.m
+++ b/sope-appserver/NGObjWeb/WOSession.m
@@ -33,10 +33,6 @@
 #include "common.h"
 #include <string.h>
 
-#if !defined(sel_get_name) && ((defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__))
-#  define sel_get_name sel_getName
-#endif
-
 #if APPLE_FOUNDATION_LIBRARY || NeXT_Foundation_LIBRARY
 @interface NSObject(Miss)
 - (id)notImplemented:(SEL)cmd;
@@ -417,7 +413,7 @@ static Class NSDateClass = Nil;
         
         diff = [[NSDateClass date] timeIntervalSince1970] - st;
         printf("prof[%s %s]: %0.3fs\n",
-               [[(WOComponent *)page name] cString], sel_get_name(_cmd), diff);
+               [[(WOComponent *)page name] cString], sel_getName(_cmd), diff);
       }
       
       WOContext_leaveComponent(_ctx, page);
@@ -459,7 +455,7 @@ static Class NSDateClass = Nil;
         
         diff = [[NSDateClass date] timeIntervalSince1970] - st;
         printf("prof[%s %s]: %0.3fs\n",
-               [[(WOComponent *)page name] cString], sel_get_name(_cmd), diff);
+               [[(WOComponent *)page name] cString], sel_getName(_cmd), diff);
       }
       
       WOContext_leaveComponent(_ctx, page);
@@ -506,8 +502,8 @@ static Class NSDateClass = Nil;
           
           diff = [[NSDateClass date] timeIntervalSince1970] - st;
           printf("prof[%s %s]: %0.3fs\n",
-                 [[page name] cString], sel_get_name(_cmd), diff);
-                 //[page name], sel_get_name(_cmd), diff);
+                 [[page name] cString], sel_getName(_cmd), diff);
+                 //[page name], sel_getName(_cmd), diff);
         }
       
         WOContext_leaveComponent(_ctx, page);
@@ -554,7 +550,7 @@ static Class NSDateClass = Nil;
         
         diff = [[NSDateClass date] timeIntervalSince1970] - st;
         printf("prof[%s %s]: %0.3fs\n",
-               [[page name] cString], sel_get_name(_cmd), diff);
+               [[page name] cString], sel_getName(_cmd), diff);
       }
       
       WOContext_leaveComponent(_ctx, page);

--- a/sope-appserver/NGObjWeb/common.h
+++ b/sope-appserver/NGObjWeb/common.h
@@ -51,13 +51,6 @@
 #include <NGExtensions/NGLogging.h>
 #include <NGStreams/NGStreams.h>
 
-#if NeXT_RUNTIME || APPLE_RUNTIME || (__GNU_LIBOBJC__ >= 20100911)
-#  ifndef sel_get_name
-#    define sel_get_name(__XXX__)    sel_getName(__XXX__)
-#    define sel_get_any_uid(__XXX__) sel_getUid(__XXX__)
-#  endif
-#endif
-
 #define IS_DEPRECATED \
   [self warnWithFormat:@"used deprecated method: %s:%i.", \
           __PRETTY_FUNCTION__, __LINE__];

--- a/sope-core/EOControl/EOKeyComparisonQualifier.m
+++ b/sope-core/EOControl/EOKeyComparisonQualifier.m
@@ -200,7 +200,7 @@ static EONull *null = nil;
     return NO;
   if (![self->rightKey isEqual:[(EOKeyComparisonQualifier *)_qual rightKey]])
     return NO;
-  if (sel_eq(self->operator, [(EOKeyComparisonQualifier *)_qual selector]))
+  if (sel_isEqual(self->operator, [(EOKeyComparisonQualifier *)_qual selector]))
     return YES;
   return NO;
 }

--- a/sope-core/EOControl/EOKeyValueCoding.m
+++ b/sope-core/EOControl/EOKeyValueCoding.m
@@ -26,7 +26,6 @@
 #if GNU_RUNTIME
 
 #if __GNU_LIBOBJC__ >= 20100911
-#  define sel_get_any_uid sel_getUid
 #  include <objc/runtime.h>
 #else
 #  include <objc/encoding.h>
@@ -152,7 +151,7 @@ static GetKeyValueBinding* newGetBinding(NSString* key, id instance)
     cbuf = malloc(clen + 1);
     [key getCString:cbuf]; cbuf[clen] = '\0';
     ckey = cbuf;
-    sel = sel_get_any_uid(ckey);
+    sel = sel_registerName(ckey);
     
     if (sel && (mth = class_get_instance_method(class, sel)) &&
         method_get_number_of_arguments(mth) == 2) {
@@ -326,7 +325,7 @@ static SetKeyValueBinding* newSetBinding(NSString* key, id instance)
     Strcat(sname, ckey);
     Strcat(sname, ":");
     sname[3] = islower((int)sname[3]) ? toupper((int)sname[3]) : sname[3];
-    sel = sel_get_any_uid(sname);
+    sel = sel_registerName(sname);
         
     if (sel && (mth = class_get_instance_method(class, sel)) &&
         method_get_number_of_arguments(mth) == 3 &&
@@ -966,7 +965,7 @@ static inline BOOL setValue(NSString* key, id instance, id value)
     strcpy(bufPtr, "ForKey:");
     if (kbuf) free(kbuf);
     
-    sel = sel_get_any_uid(buf);
+    sel = sel_registerName(buf);
     if (buf) free(buf);
     
     return sel != NULL ? [self performSelector:sel withObject:_key] : nil;
@@ -1531,11 +1530,7 @@ static void doubleIvarSetFunc(void* info1, void* info2, id self, id val) {
     strcpy(bufPtr, "ForKey:");
     if (kbuf) free(kbuf);
 
-#if NeXT_RUNTIME
-    sel = sel_getUid(buf);
-#else    
-    sel = sel_get_any_uid(buf);
-#endif
+    sel = sel_registerName(buf);
     if (buf) free(buf);
     
     return sel != NULL ? [self performSelector:sel withObject:_key] : nil;

--- a/sope-core/EOControl/EOKeyValueQualifier.m
+++ b/sope-core/EOControl/EOKeyValueQualifier.m
@@ -227,7 +227,7 @@ static EONull *null = nil;
     return NO;
   if (![self->value isEqual:[(EOKeyValueQualifier *)_qual value]])
     return NO;
-  if (sel_eq(self->operator, [(EOKeyValueQualifier *)_qual selector]))
+  if (sel_isEqual(self->operator, [(EOKeyValueQualifier *)_qual selector]))
     return YES;
   return NO;
 }

--- a/sope-core/EOControl/EOObserver.m
+++ b/sope-core/EOControl/EOObserver.m
@@ -109,11 +109,7 @@ static NSMapTable     *objectToObservers   = NULL;
     }
   }
 
-#if NeXT_RUNTIME
   nl = malloc(sizeof(EOObserverList));
-#else  
-  nl = objc_malloc(sizeof(EOObserverList));
-#endif
   nl->observer = [_observer retain];
   nl->notify   = (void*)
     [(id)_observer methodForSelector:@selector(objectWillChange:)];
@@ -149,11 +145,7 @@ static NSMapTable     *objectToObservers   = NULL;
         /* entry is not the first entry */
         ll->next = l->next;
         [l->observer release];
-#if NeXT_RUNTIME
         free(l);
-#else    
-        objc_free(l);
-#endif
         break;
       }
       else if (l->next) {
@@ -167,22 +159,14 @@ static NSMapTable     *objectToObservers   = NULL;
         l->observer = ll->observer;
         l->notify   = ll->notify;
         l->next     = ll->next;
-#if NeXT_RUNTIME
         free(ll);
-#else    
-        objc_free(ll);
-#endif
         break;
       }
       else {
         /* entry is the lone entry */
         NSMapRemove(objectToObservers, _object);
         [l->observer release];
-#if NeXT_RUNTIME
         free(l);
-#else    
-        objc_free(l);
-#endif
         break;
       }
     }
@@ -233,11 +217,7 @@ static NSMapTable     *objectToObservers   = NULL;
       return;
   }
 
-#if NeXT_RUNTIME
   l = malloc(sizeof(EOObserverList));
-#else  
-  l = objc_malloc(sizeof(EOObserverList));
-#endif
   l->next     = omniscientObservers;
   l->observer = [_observer retain];
   l->notify   = (void*)[(id)_observer methodForSelector:@selector(willChange:)];
@@ -258,7 +238,7 @@ static NSMapTable     *objectToObservers   = NULL;
         ll->next = l->next;
 
       [l->observer release];
-      objc_free(l);
+      free(l);
       return;
     }
 

--- a/sope-core/EOControl/EOOrQualifier.m
+++ b/sope-core/EOControl/EOOrQualifier.m
@@ -52,7 +52,7 @@ static BOOL debugTransform = NO;
   if (c == 0)
     return [self initWithQualifierArray:nil];
 
-  qs = objc_calloc(c, sizeof(id));
+  qs = calloc(c, sizeof(id));
   
   va_start(va, _qual1);
   for (c = 0, q = _qual1; q != nil; q = va_arg(va, id), c++) {
@@ -61,7 +61,7 @@ static BOOL debugTransform = NO;
   va_end(va);
 
   a = [NSArray arrayWithObjects:qs count:c];
-  objc_free(qs);
+  free(qs);
   
   return [self initWithQualifierArray:a];
 }

--- a/sope-core/EOControl/EOSortOrdering.m
+++ b/sope-core/EOControl/EOSortOrdering.m
@@ -28,14 +28,6 @@
 #  include <objc/objc.h>
 #endif
 
-#ifndef SEL_EQ
-#  if GNU_RUNTIME
-#    define SEL_EQ(sel1,sel2) sel_eq(sel1,sel2)
-#  else
-#    define SEL_EQ(sel1,sel2) (sel1 == sel2)
-#  endif
-#endif
-
 @implementation EOSortOrdering
 /*"
   This class specifies a sort-ordering as used with
@@ -83,7 +75,7 @@
 /* equality */
 
 - (BOOL)isEqualToSortOrdering:(EOSortOrdering *)_sortOrdering {
-  if (!SEL_EQ([_sortOrdering selector], [self selector]))
+  if (!sel_isEqual([_sortOrdering selector], [self selector]))
     return NO;
   if (![[_sortOrdering key] isEqualToString:[self key]])
     return NO;

--- a/sope-core/EOControl/EOValidation.m
+++ b/sope-core/EOControl/EOValidation.m
@@ -24,10 +24,6 @@
 #include "EONull.h"
 #include "common.h"
 
-#if __GNU_LIBOBJC__ >= 20100911
-#  define sel_get_any_uid sel_getUid
-#endif
-
 #if !LIB_FOUNDATION_LIBRARY
 
 @interface NSException(UsedSetUI) /* does Jaguar allow -setUserInfo: ? */
@@ -150,11 +146,7 @@
     strcat(buf, ":");
     buf[8] = toupper(buf[8]);
     
-#if NeXT_RUNTIME
-    sel = sel_getUid(buf);
-#else
-    sel = sel_get_any_uid(buf);
-#endif
+    sel = sel_registerName(buf);
     if (sel) {
       if ([self respondsToSelector:sel]) {
         if (buf) free(buf);

--- a/sope-core/EOControl/common.h
+++ b/sope-core/EOControl/common.h
@@ -30,22 +30,6 @@
 #import <Foundation/Foundation.h>
 #import <Foundation/NSObjCRuntime.h>
 
-#if NeXT_RUNTIME || APPLE_RUNTIME
-#  define objc_free(__mem__)    free(__mem__)
-#  define objc_malloc(__size__) malloc(__size__)
-#  define objc_calloc(__cnt__, __size__) calloc(__cnt__, __size__)
-#  define objc_realloc(__ptr__, __size__) realloc(__ptr__, __size__)
-#  ifndef sel_eq
-#    define sel_eq(sela,selb) (sela==selb?YES:NO)
-#  endif
-#endif
-
-#if __GNU_LIBOBJC__ >= 20100911
-#  ifndef sel_eq
-#    define sel_eq(__A__,__B__) sel_isEqual(__A__,__B__)
-#  endif
-#endif
-
 #ifndef ASSIGN
 #  define ASSIGN(object, value) \
        ({id __object = (id)object;    \

--- a/sope-core/EOCoreData/EOKeyComparisonQualifier+CoreData.m
+++ b/sope-core/EOCoreData/EOKeyComparisonQualifier+CoreData.m
@@ -66,7 +66,7 @@
 }
 
 - (unsigned)options {
-  return (SEL_EQ([self selector], EOQualifierOperatorCaseInsensitiveLike))
+  return (sel_isEqual([self selector], EOQualifierOperatorCaseInsensitiveLike))
     ? NSCaseInsensitivePredicateOption : 0;
 }
 

--- a/sope-core/EOCoreData/EOKeyValueQualifier+CoreData.m
+++ b/sope-core/EOCoreData/EOKeyValueQualifier+CoreData.m
@@ -71,7 +71,7 @@
 }
 
 - (unsigned)options {
-  return (SEL_EQ([self selector], EOQualifierOperatorCaseInsensitiveLike))
+  return (sel_isEqual([self selector], EOQualifierOperatorCaseInsensitiveLike))
     ? NSCaseInsensitivePredicateOption : 0;
 }
 

--- a/sope-core/EOCoreData/EOQualifier+CoreData.m
+++ b/sope-core/EOCoreData/EOQualifier+CoreData.m
@@ -52,26 +52,26 @@
 @implementation EOQualifier(CoreData)
 
 + (NSPredicateOperatorType)predicateOperatorTypeForEOSelector:(SEL)_sel {
-  if (SEL_EQ(_sel, EOQualifierOperatorEqual))
+  if (sel_isEqual(_sel, EOQualifierOperatorEqual))
     return NSEqualToPredicateOperatorType;
-  if (SEL_EQ(_sel, EOQualifierOperatorNotEqual))
+  if (sel_isEqual(_sel, EOQualifierOperatorNotEqual))
     return NSNotEqualToPredicateOperatorType;
   
-  if (SEL_EQ(_sel, EOQualifierOperatorLessThan))
+  if (sel_isEqual(_sel, EOQualifierOperatorLessThan))
     return NSLessThanPredicateOperatorType;
-  if (SEL_EQ(_sel, EOQualifierOperatorGreaterThan))
+  if (sel_isEqual(_sel, EOQualifierOperatorGreaterThan))
     return NSGreaterThanPredicateOperatorType;
   
-  if (SEL_EQ(_sel, EOQualifierOperatorLessThanOrEqualTo))
+  if (sel_isEqual(_sel, EOQualifierOperatorLessThanOrEqualTo))
     return NSLessThanOrEqualToPredicateOperatorType;
-  if (SEL_EQ(_sel, EOQualifierOperatorGreaterThanOrEqualTo))
+  if (sel_isEqual(_sel, EOQualifierOperatorGreaterThanOrEqualTo))
     return NSGreaterThanOrEqualToPredicateOperatorType;
   
-  if (SEL_EQ(_sel, EOQualifierOperatorContains))
+  if (sel_isEqual(_sel, EOQualifierOperatorContains))
     return NSInPredicateOperatorType;
   
-  if (SEL_EQ(_sel, EOQualifierOperatorLike) ||
-      SEL_EQ(_sel, EOQualifierOperatorCaseInsensitiveLike))
+  if (sel_isEqual(_sel, EOQualifierOperatorLike) ||
+      sel_isEqual(_sel, EOQualifierOperatorCaseInsensitiveLike))
     return NSLikePredicateOperatorType;
   
   return NSCustomSelectorPredicateOperatorType;
@@ -164,7 +164,7 @@
   pmod  = NSDirectPredicateModifier;
   popts = 0;
   
-  if (SEL_EQ(_selector, EOQualifierOperatorCaseInsensitiveLike))
+  if (sel_isEqual(_selector, EOQualifierOperatorCaseInsensitiveLike))
     popts = NSCaseInsensitivePredicateOption;
   
   return [NSComparisonPredicate predicateWithLeftExpression:_lhs

--- a/sope-core/EOCoreData/EOSortOrdering+CoreData.m
+++ b/sope-core/EOCoreData/EOSortOrdering+CoreData.m
@@ -33,12 +33,12 @@
   }
   
   sel = [_descriptor selector];
-  if (SEL_EQ(sel, @selector(compare:))) {
+  if (sel_isEqual(sel, @selector(compare:))) {
     sel = [_descriptor ascending] 
       ? EOCompareAscending
       : EOCompareDescending;
   }
-  else if (SEL_EQ(sel, @selector(caseInsensitiveCompare:))) {
+  else if (sel_isEqual(sel, @selector(caseInsensitiveCompare:))) {
     sel = [_descriptor ascending] 
       ? EOCompareCaseInsensitiveAscending
       : EOCompareCaseInsensitiveDescending;
@@ -54,18 +54,18 @@
 }
 
 - (BOOL)isAscendingEOSortSelector:(SEL)_sel {
-  if (SEL_EQ(_sel, EOCompareDescending)) return NO;
-  if (SEL_EQ(_sel, EOCompareCaseInsensitiveAscending)) return NO;
+  if (sel_isEqual(_sel, EOCompareDescending)) return NO;
+  if (sel_isEqual(_sel, EOCompareCaseInsensitiveAscending)) return NO;
   return YES;
 }
 
 - (SEL)cdSortSelectorFromEOSortSelector:(SEL)_sel {
-  if (SEL_EQ(_sel, EOCompareAscending))  return @selector(compare:);
-  if (SEL_EQ(_sel, EOCompareDescending)) return @selector(compare:);
+  if (sel_isEqual(_sel, EOCompareAscending))  return @selector(compare:);
+  if (sel_isEqual(_sel, EOCompareDescending)) return @selector(compare:);
   
-  if (SEL_EQ(_sel, EOCompareCaseInsensitiveAscending))
+  if (sel_isEqual(_sel, EOCompareCaseInsensitiveAscending))
     return @selector(caseInsensitiveCompare:);
-  if (SEL_EQ(_sel, EOCompareCaseInsensitiveDescending))
+  if (sel_isEqual(_sel, EOCompareCaseInsensitiveDescending))
     return @selector(caseInsensitiveCompare:);
   
   return _sel;

--- a/sope-core/EOCoreData/common.h
+++ b/sope-core/EOCoreData/common.h
@@ -56,12 +56,4 @@
 #  include <objc/objc.h>
 #endif
 
-#ifndef SEL_EQ
-#  if GNU_RUNTIME
-#    define SEL_EQ(sel1,sel2) sel_eq(sel1,sel2)
-#  else
-#    define SEL_EQ(sel1,sel2) (sel1 == sel2)
-#  endif
-#endif
-
 #endif /* __EOCoreData_COMMON_H__ */

--- a/sope-core/NGExtensions/EOExt.subproj/EOQualifier+CtxEval.m
+++ b/sope-core/NGExtensions/EOExt.subproj/EOQualifier+CtxEval.m
@@ -30,20 +30,18 @@
 #  import <extensions/objc-runtime.h>
 #elif GNUSTEP_BASE_LIBRARY
 #if __GNU_LIBOBJC__ >= 20100911
-#  define sel_get_name sel_getName
 #  import <objc/runtime.h>
 #else
 #  import <objc/objc-api.h>
 #endif
 #else
 #  import <objc/objc.h>
-#  define sel_get_name sel_getName
 #endif
 
 static inline int countSelArgs(SEL _sel) {
   register const char *selName;
 
-  if ((selName = sel_get_name(_sel))) {
+  if ((selName = sel_getName(_sel))) {
     register int count;
     
     for (count = 0; *selName; selName++) {

--- a/sope-core/NGExtensions/NGExtensions/NGMemoryAllocation.h
+++ b/sope-core/NGExtensions/NGExtensions/NGMemoryAllocation.h
@@ -28,16 +28,9 @@
 
 #include <stdlib.h>
 
-#if LIB_FOUNDATION_BOEHM_GC
-#  define NGMalloc       objc_malloc
-#  define NGMallocAtomic objc_atomic_malloc
-#  define NGFree         objc_free
-#  define NGRealloc      objc_realloc
-#else
-#  define NGMalloc       malloc
-#  define NGMallocAtomic malloc
-#  define NGFree         free
-#  define NGRealloc      realloc
-#endif
+#define NGMalloc       malloc
+#define NGMallocAtomic malloc
+#define NGFree         free
+#define NGRealloc      realloc
 
 #endif /* __NGExtensions_NGMemoryAllocation_H__ */

--- a/sope-core/NGStreams/NGByteCountStream.m
+++ b/sope-core/NGStreams/NGByteCountStream.m
@@ -85,10 +85,9 @@
 
   totalReadCount += result;
   {
-    NSInteger len;
     register unsigned char *byteBuffer = _buf;
 
-    for (len = result - 1; len >= 0; len--, byteBuffer++) {
+    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteReadCount++;
     }
@@ -105,10 +104,9 @@
 
   totalWriteCount += result;
   {
-    NSInteger len;
     register unsigned char *byteBuffer = (unsigned char *)_buf;
 
-    for (len = result - 1; len >= 0; len--, byteBuffer++) {
+    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteWriteCount++;
     }

--- a/sope-core/NGStreams/NGByteCountStream.m
+++ b/sope-core/NGStreams/NGByteCountStream.m
@@ -85,9 +85,10 @@
 
   totalReadCount += result;
   {
+    NSInteger len;
     register unsigned char *byteBuffer = _buf;
 
-    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
+    for (len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteReadCount++;
     }
@@ -104,9 +105,10 @@
 
   totalWriteCount += result;
   {
+    NSInteger len;
     register unsigned char *byteBuffer = (unsigned char *)_buf;
 
-    for (NSInteger len = result - 1; len >= 0; len--, byteBuffer++) {
+    for (len = result - 1; len >= 0; len--, byteBuffer++) {
       if (*byteBuffer == byteToCount)
         byteWriteCount++;
     }

--- a/sope-core/NGStreams/NGStreamCoder.m
+++ b/sope-core/NGStreams/NGStreamCoder.m
@@ -587,7 +587,7 @@ FINAL void _readObjC(NGStreamCoder *self, void *_value, const char *_type);
 
     case _C_SEL:
       _writeTag(self, _C_SEL);
-      _writeCString(self, (*(SEL *)_value) ? sel_get_name(*(SEL *)_value) : NULL);
+      _writeCString(self, (*(SEL *)_value) ? sel_getName(*(SEL *)_value) : NULL);
       break;
       
     case _C_PTR:
@@ -899,7 +899,7 @@ FINAL void _readObjC(NGStreamCoder *self, void *_value, const char *_type);
       
       NSAssert(*_type == tag, @"invalid type ..");
       _readObjC(self, &name, @encode(char *));
-      *(SEL *)_value = name ? sel_get_any_uid(name) : NULL;
+      *(SEL *)_value = name ? sel_registerName(name) : NULL;
       NGFree(name); name = NULL;
     }
 

--- a/sope-gdl1/GDLAccess/EOAdaptorDataSource.m
+++ b/sope-gdl1/GDLAccess/EOAdaptorDataSource.m
@@ -1023,15 +1023,15 @@ static NSNotificationCenter *getNC(void ) {
         [orderByExpr appendString:@", "];
       
       if ((selector = [sortOrdering selector])) {
-        if (SEL_EQ(selector, EOCompareAscending))
+        if (sel_isEqual(selector, EOCompareAscending))
           order = 1;
-        else if (SEL_EQ(selector, EOCompareDescending))
+        else if (sel_isEqual(selector, EOCompareDescending))
           order = 2;
-        else if (SEL_EQ(selector, EOCompareCaseInsensitiveAscending)) {
+        else if (sel_isEqual(selector, EOCompareCaseInsensitiveAscending)) {
 	  order       = 1;
 	  inSensitive = YES;
 	}
-        else if (SEL_EQ(selector, EOCompareCaseInsensitiveDescending)) {
+        else if (sel_isEqual(selector, EOCompareCaseInsensitiveDescending)) {
 	  order       = 2;
 	  inSensitive = YES;
 	}
@@ -1359,38 +1359,38 @@ static NSNotificationCenter *getNC(void ) {
 
   sql = nil;
   
-  if (SEL_EQ(EOQualifierOperatorEqual, self->operator)) {
+  if (sel_isEqual(EOQualifierOperatorEqual, self->operator)) {
     if ([self->value isNotNull])
       sql = [NSString stringWithFormat:@"%@ = %@", sqlKey, sqlValue];
     else
       sql = [NSString stringWithFormat:@"%@ IS NULL", sqlKey];
   }
-  else if (SEL_EQ(EOQualifierOperatorNotEqual, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorNotEqual, self->operator)) {
     if ([self->value isNotNull])
       sql = [NSString stringWithFormat:@"NOT (%@ = %@)", sqlKey, sqlValue];
     else
       sql = [NSString stringWithFormat:@"%@ IS NOT NULL", sqlKey];
   }
-  else if (SEL_EQ(EOQualifierOperatorLessThan, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorLessThan, self->operator)) {
     sql = [NSString stringWithFormat:@"%@ < %@", sqlKey, sqlValue];
   }
-  else if (SEL_EQ(EOQualifierOperatorLessThanOrEqualTo, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorLessThanOrEqualTo, self->operator)) {
     sql = [NSString stringWithFormat:@"%@ <= %@", sqlKey, sqlValue];
   }
-  else if (SEL_EQ(EOQualifierOperatorGreaterThan, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorGreaterThan, self->operator)) {
     sql = [NSString stringWithFormat:@"%@ > %@", sqlKey, sqlValue];
   }
-  else if (SEL_EQ(EOQualifierOperatorGreaterThanOrEqualTo, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorGreaterThanOrEqualTo, self->operator)) {
     sql = [NSString stringWithFormat:@"%@ >= %@", sqlKey, sqlValue];
   }
-  else if (SEL_EQ(EOQualifierOperatorLike, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorLike, self->operator)) {
     sqlValue = [[self->value stringValue]
                              stringByReplacingString:@"*" withString:@"%"];
     sqlValue = [_adaptor formatValue:sqlValue forAttribute:attr];
     
     sql = [NSString stringWithFormat:@"%@ LIKE %@", sqlKey, sqlValue];
   }
-  else if (SEL_EQ(EOQualifierOperatorCaseInsensitiveLike, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorCaseInsensitiveLike, self->operator)) {
     sqlValue = [[self->value stringValue]
                              stringByReplacingString:@"*" withString:@"%"];
     sqlValue = [sqlValue lowercaseString];
@@ -1399,9 +1399,9 @@ static NSNotificationCenter *getNC(void ) {
     sql = [NSString stringWithFormat:@"LOWER(%@) LIKE %@", sqlKey, sqlValue];
   }
 #if 0
-  else if (SEL_EQ(EOQualifierOperatorLessThanOrEqualTo, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorLessThanOrEqualTo, self->operator)) {
   }
-  else if (SEL_EQ(EOQualifierOperatorGreaterThanOrEqualTo, self->operator)) {
+  else if (sel_isEqual(EOQualifierOperatorGreaterThanOrEqualTo, self->operator)) {
   }
 #endif
   else {

--- a/sope-gdl1/GDLAccess/EOAttribute.m
+++ b/sope-gdl1/GDLAccess/EOAttribute.m
@@ -535,11 +535,7 @@ static inline void _addToPropList(NSMutableDictionary *propertyList,
     return @"";
 
   clen = [self cStringLength];
-#if GNU_RUNTIME
-  s = objc_atomic_malloc(clen + 4);
-#else
   s = malloc(clen + 4);
-#endif
 
   [self getCString:s maxLength:clen];
     

--- a/sope-gdl1/GDLAccess/EOEntity.m
+++ b/sope-gdl1/GDLAccess/EOEntity.m
@@ -1100,11 +1100,7 @@ static inline void _addToPropList(NSMutableDictionary *propertyList,
     unsigned cnt, cnt2;
 
     clen = [self cStringLength];
-#if GNU_RUNTIME
-    s = objc_atomic_malloc(clen + 4);
-#else
     s = malloc(clen + 4);
-#endif
 
     [self getCString:s maxLength:clen];
     

--- a/sope-gdl1/GDLAccess/EOFault.m
+++ b/sope-gdl1/GDLAccess/EOFault.m
@@ -381,7 +381,7 @@ static inline void _resolveFault(EOFault *self) {
 
     r = [NSString stringWithFormat:
 		    @"fault error: resolved fault does not responds to selector %s",
-		    sel_get_name(sel)];
+		    sel_getName(sel)];
     [NSException raise:@"NSInvalidArgumentException" reason:r userInfo:nil];
   }
   return objc_msg_sendv(self, sel, args);

--- a/sope-gdl1/GDLAccess/EOKeyComparisonQualifier+SQL.m
+++ b/sope-gdl1/GDLAccess/EOKeyComparisonQualifier+SQL.m
@@ -36,19 +36,19 @@
   EOSQLQualifier *q;
   NSString *format;
 
-  if (SEL_EQ(self->operator, EOQualifierOperatorEqual))
+  if (sel_isEqual(self->operator, EOQualifierOperatorEqual))
       format = @"%A = %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorNotEqual))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorNotEqual))
       format = @"%A <> %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLessThan))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLessThan))
       format = @"%A < %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorGreaterThan))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorGreaterThan))
       format = @"%A > %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLessThanOrEqualTo))
       format = @"%A <= %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorGreaterThanOrEqualTo))
       format = @"%A >= %A";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLike))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLike))
       format = @"%A LIKE %A";
   else {
       format = [NSString stringWithFormat:@"%%A %@ %%A",

--- a/sope-gdl1/GDLAccess/EOKeyValueQualifier+SQL.m
+++ b/sope-gdl1/GDLAccess/EOKeyValueQualifier+SQL.m
@@ -36,19 +36,19 @@
   EOSQLQualifier *q;
   NSString *format;
   
-  if (SEL_EQ(self->operator,  EOQualifierOperatorEqual))
+  if (sel_isEqual(self->operator,  EOQualifierOperatorEqual))
       format = @"%A = %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorNotEqual))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorNotEqual))
       format = @"%A <> %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLessThan))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLessThan))
       format = @"%A < %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorGreaterThan))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorGreaterThan))
       format = @"%A > %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLessThanOrEqualTo))
       format = @"%A <= %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorGreaterThanOrEqualTo))
       format = @"%A >= %@";
-  else if (SEL_EQ(self->operator, EOQualifierOperatorLike))
+  else if (sel_isEqual(self->operator, EOQualifierOperatorLike))
       format = @"%A LIKE %@";
   else {
       format = [NSString stringWithFormat:@"%%A %@ %%@",

--- a/sope-gdl1/GDLAccess/EOSQLExpression.m
+++ b/sope-gdl1/GDLAccess/EOSQLExpression.m
@@ -480,20 +480,20 @@ NSString *EOBindVariableValueKey       = @"value";
       ordering  = [order selector];
       attribute = [self->entity attributeNamed:[order key]];
 
-      if (sel_eq(ordering, EOCompareCaseInsensitiveAscending) ||
-          sel_eq(ordering, EOCompareCaseInsensitiveDescending))
+      if (sel_isEqual(ordering, EOCompareCaseInsensitiveAscending) ||
+          sel_isEqual(ordering, EOCompareCaseInsensitiveDescending))
         fmt = @"LOWER(%@)";
       else
         fmt = @"%@";
       
       [orderBy appendFormat:fmt, [self expressionValueForAttribute:attribute]];
 
-      if (sel_eq(ordering, EOCompareCaseInsensitiveAscending) ||
-          sel_eq(ordering, EOCompareAscending)) {
+      if (sel_isEqual(ordering, EOCompareCaseInsensitiveAscending) ||
+          sel_isEqual(ordering, EOCompareAscending)) {
         [orderBy appendString:@" ASC"];
       }
-      else if (sel_eq(ordering, EOCompareCaseInsensitiveDescending) ||
-               sel_eq(ordering, EOCompareDescending)) {
+      else if (sel_isEqual(ordering, EOCompareCaseInsensitiveDescending) ||
+               sel_isEqual(ordering, EOCompareDescending)) {
         [orderBy appendString:@" DESC"];
       }
     }
@@ -1153,27 +1153,27 @@ NSString *EOBindVariableValueKey       = @"value";
 
 - (NSString *)sqlStringForSelector:(SEL)_selector value:(id)_value {
   if ((_value == null) || (_value == nil)) {
-    if (sel_eq(_selector, EOQualifierOperatorEqual))
+    if (sel_isEqual(_selector, EOQualifierOperatorEqual))
       return @"is";
-    else if (sel_eq(_selector, EOQualifierOperatorNotEqual))
+    else if (sel_isEqual(_selector, EOQualifierOperatorNotEqual))
       return @"is not";
   }
   else {
-    if (sel_eq(_selector, EOQualifierOperatorEqual))
+    if (sel_isEqual(_selector, EOQualifierOperatorEqual))
       return @"=";
-    else if (sel_eq(_selector, EOQualifierOperatorNotEqual))
+    else if (sel_isEqual(_selector, EOQualifierOperatorNotEqual))
       return @"<>";
   }
   
-  if (sel_eq(_selector, EOQualifierOperatorLessThan))
+  if (sel_isEqual(_selector, EOQualifierOperatorLessThan))
     return @"<";
-  else if (sel_eq(_selector, EOQualifierOperatorGreaterThan))
+  else if (sel_isEqual(_selector, EOQualifierOperatorGreaterThan))
     return @">";
-  else if (sel_eq(_selector, EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(_selector, EOQualifierOperatorLessThanOrEqualTo))
     return @"<=";
-  else if (sel_eq(_selector, EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(_selector, EOQualifierOperatorGreaterThanOrEqualTo))
     return @">=";
-  else if (sel_eq(_selector, EOQualifierOperatorLike))
+  else if (sel_isEqual(_selector, EOQualifierOperatorLike))
     return @"LIKE";
   else {
     return [NSString stringWithFormat:@"UNKNOWN<%@>",

--- a/sope-gdl1/GDLAccess/common.h
+++ b/sope-gdl1/GDLAccess/common.h
@@ -48,20 +48,6 @@
 
 #import <Foundation/NSObjCRuntime.h>
 
-#if NeXT_RUNTIME || APPLE_RUNTIME
-#  define sel_eq(sela,selb) (sela==selb?YES:NO)
-#  ifndef SEL_EQ
-#    define SEL_EQ(__A__,__B__) (__A__==__B__?YES:NO)
-#  endif
-#endif
-
-#if __GNU_LIBOBJC__ >= 20100911
-#  define sel_eq(__A__,__B__) sel_isEqual(__A__,__B__)
-#  ifndef SEL_EQ
-#    define SEL_EQ(__A__,__B__) sel_isEqual(__A__,__B__)
-#  endif
-#endif
-
 #if LIB_FOUNDATION_LIBRARY
 #  import <extensions/objc-runtime.h>
 #else
@@ -242,17 +228,6 @@ static inline char *Ltoa(long nr, char *str, int base)
 - (void)notImplemented:(SEL)sel;
 @end
 
-#endif
-
-#if !GNU_RUNTIME
-#  ifndef SEL_EQ
-#    define SEL_EQ(__A__,__B__) (__A__==__B__ ? YES : NO)
-#  endif
-#else
-#  ifndef SEL_EQ
-#    include <objc/objc.h>
-#    define SEL_EQ(__A__,__B__) sel_eq(__A__,__B__)
-#  endif
 #endif
 
 #endif /* __common_h__ */

--- a/sope-ldap/NGLdap/EOQualifier+LDAP.m
+++ b/sope-ldap/NGLdap/EOQualifier+LDAP.m
@@ -22,14 +22,6 @@
 #include "EOQualifier+LDAP.h"
 #include "common.h"
 
-#if NeXT_RUNTIME
-#define sel_eq(sel1, sel2) ((sel1)) == ((sel2))
-#endif
-
-#if __GNU_LIBOBJC__ >= 20100911
-#  define sel_eq(__A__,__B__) sel_isEqual(__A__,__B__)
-#endif
-
 @interface EOQualifier(LDAPPrivates)
 
 - (void)addToLDAPFilterString:(NSMutableString *)_s inContext:(id)_ctx;
@@ -123,29 +115,29 @@
 
   sel = [self selector];
 
-  if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@"(!"];
   
   [_s appendString:@"("];
   [_s appendString:[self key]];
 
-  if (sel_eq(sel,  EOQualifierOperatorEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorEqual))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  else if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorLessThan))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLessThan))
     [_s appendString:@"<"];
-  else if (sel_eq(sel,  EOQualifierOperatorGreaterThan))
+  else if (sel_isEqual(sel,  EOQualifierOperatorGreaterThan))
     [_s appendString:@">"];
-  else if (sel_eq(sel,  EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLessThanOrEqualTo))
     [_s appendString:@"<="];
-  else if (sel_eq(sel,  EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(sel,  EOQualifierOperatorGreaterThanOrEqualTo))
     [_s appendString:@">="];
-  else if (sel_eq(sel,  EOQualifierOperatorContains))
+  else if (sel_isEqual(sel,  EOQualifierOperatorContains))
     [_s appendString:@"=*"];
-  else if (sel_eq(sel,  EOQualifierOperatorLike))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLike))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorCaseInsensitiveLike))
+  else if (sel_isEqual(sel,  EOQualifierOperatorCaseInsensitiveLike))
     [_s appendString:@"="];
   else {
     NSLog(@"UNKNOWN operator: %@", NSStringFromSelector([self selector]));
@@ -155,7 +147,7 @@
   [_s appendString:[[self value] description]];
   [_s appendString:@")"];
   
-  if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@")"];
 }
 
@@ -169,29 +161,29 @@
 
   sel = [self selector];
 
-  if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@"(!"];
   
   [_s appendString:@"("];
   [_s appendString:[self leftKey]];
 
-  if (sel_eq(sel,  EOQualifierOperatorEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorEqual))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  else if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorLessThan))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLessThan))
     [_s appendString:@"<"];
-  else if (sel_eq(sel,  EOQualifierOperatorGreaterThan))
+  else if (sel_isEqual(sel,  EOQualifierOperatorGreaterThan))
     [_s appendString:@">"];
-  else if (sel_eq(sel,  EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLessThanOrEqualTo))
     [_s appendString:@"<="];
-  else if (sel_eq(sel,  EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(sel,  EOQualifierOperatorGreaterThanOrEqualTo))
     [_s appendString:@">="];
-  else if (sel_eq(sel,  EOQualifierOperatorContains))
+  else if (sel_isEqual(sel,  EOQualifierOperatorContains))
     [_s appendString:@"=*"];
-  else if (sel_eq(sel,  EOQualifierOperatorLike))
+  else if (sel_isEqual(sel,  EOQualifierOperatorLike))
     [_s appendString:@"="];
-  else if (sel_eq(sel,  EOQualifierOperatorCaseInsensitiveLike))
+  else if (sel_isEqual(sel,  EOQualifierOperatorCaseInsensitiveLike))
     [_s appendString:@"="];
   else {
     NSLog(@"UNKNOWN operator: %@", NSStringFromSelector([self selector]));
@@ -201,7 +193,7 @@
   [_s appendString:[self rightKey]];
   [_s appendString:@")"];
   
-  if (sel_eq(sel,  EOQualifierOperatorNotEqual))
+  if (sel_isEqual(sel,  EOQualifierOperatorNotEqual))
     [_s appendString:@")"];
 }
 

--- a/sope-mime/NGImap4/EOQualifier+IMAPAdditions.m
+++ b/sope-mime/NGImap4/EOQualifier+IMAPAdditions.m
@@ -267,10 +267,10 @@ static void _initImap4SearchCategory(void) {
 
   // TODO: add support for <> qualifier? (seen => unseen)
       
-  if (sel_eq(lselector, EOQualifierOperatorEqual)) {
+  if (sel_isEqual(lselector, EOQualifierOperatorEqual)) {
     lvalue = [NSArray arrayWithObject:lvalue];
   }
-  else if (!sel_eq(lselector, EOQualifierOperatorContains)) {
+  else if (!sel_isEqual(lselector, EOQualifierOperatorContains)) {
     return [self invalidImap4SearchQualifier:
 		   @"unexpected EOKeyValueQualifier selector"];
   }
@@ -299,13 +299,13 @@ static void _initImap4SearchCategory(void) {
 andComparisonSelector:(SEL)lselector {
   NSString *operatorPrefix, *dateOperator, *imap4Operator;
 
-  if (sel_eq(lselector, EOQualifierOperatorEqual))
+  if (sel_isEqual(lselector, EOQualifierOperatorEqual))
     dateOperator = @"ON";
-  else if (sel_eq(lselector, EOQualifierOperatorGreaterThan)
-	   || sel_eq(lselector, EOQualifierOperatorGreaterThanOrEqualTo))
+  else if (sel_isEqual(lselector, EOQualifierOperatorGreaterThan)
+	   || sel_isEqual(lselector, EOQualifierOperatorGreaterThanOrEqualTo))
     dateOperator = @"SINCE";
-  else if (sel_eq(lselector, EOQualifierOperatorLessThan)
-	   || sel_eq(lselector, EOQualifierOperatorLessThanOrEqualTo))
+  else if (sel_isEqual(lselector, EOQualifierOperatorLessThan)
+	   || sel_isEqual(lselector, EOQualifierOperatorLessThanOrEqualTo))
     dateOperator = @"BEFORE";
   else
     dateOperator = nil;
@@ -371,7 +371,7 @@ andComparisonSelector:(SEL)lselector {
   }
 
   if ([lkey isEqualToString:@"UID"]) {
-    if (!sel_eq(lselector, EOQualifierOperatorEqual)) {
+    if (!sel_isEqual(lselector, EOQualifierOperatorEqual)) {
       return [self invalidImap4SearchQualifier:@"unexpected qualifier 2"];
     }
     
@@ -381,7 +381,7 @@ andComparisonSelector:(SEL)lselector {
   }
 
   if ([lkey isEqualToString:@"MODSEQ"]) {
-    if (!sel_eq(lselector, EOQualifierOperatorGreaterThanOrEqualTo)) {
+    if (!sel_isEqual(lselector, EOQualifierOperatorGreaterThanOrEqualTo)) {
       return [self invalidImap4SearchQualifier:@"'MODSEQ' can only take 'EOQualifierOperatorGreaterThanOrEqualTo' as qualifier operator"];
     }
     
@@ -391,11 +391,11 @@ andComparisonSelector:(SEL)lselector {
   }
   
   if ([lkey isEqualToString:@"SIZE"]) {
-    if (sel_eq(lselector, EOQualifierOperatorGreaterThan)
-	|| sel_eq(lselector, EOQualifierOperatorGreaterThanOrEqualTo))
+    if (sel_isEqual(lselector, EOQualifierOperatorGreaterThan)
+	|| sel_isEqual(lselector, EOQualifierOperatorGreaterThanOrEqualTo))
       [search appendString:@"LARGER "];
-    else if (sel_eq(lselector, EOQualifierOperatorLessThan)
-	     || sel_eq(lselector, EOQualifierOperatorLessThanOrEqualTo))
+    else if (sel_isEqual(lselector, EOQualifierOperatorLessThan)
+	     || sel_isEqual(lselector, EOQualifierOperatorLessThanOrEqualTo))
       [search appendString:@"SMALLER "];
     else
       return [self invalidImap4SearchQualifier:@"unexpected qualifier 3"];
@@ -416,9 +416,9 @@ andComparisonSelector:(SEL)lselector {
 
        Would be: "a caseInsensitiveLike: '*ABC*'"
     */
-    if (!sel_eq(lselector, EOQualifierOperatorEqual) &&
-	!sel_eq(lselector, EOQualifierOperatorCaseInsensitiveLike) &&
-	!sel_eq(lselector, EOQualifierOperatorContains)) {
+    if (!sel_isEqual(lselector, EOQualifierOperatorEqual) &&
+	!sel_isEqual(lselector, EOQualifierOperatorCaseInsensitiveLike) &&
+	!sel_isEqual(lselector, EOQualifierOperatorContains)) {
       [self logWithFormat:@"IMAP4 generation: got: %@, allowed: %@", 
 	    NSStringFromSelector(lselector),
 	    NSStringFromSelector(EOQualifierOperatorEqual)];
@@ -435,8 +435,8 @@ andComparisonSelector:(SEL)lselector {
   }
   
   
-  if (!sel_eq(lselector, EOQualifierOperatorEqual) &&
-      !sel_eq(lselector, EOQualifierOperatorCaseInsensitiveLike))
+  if (!sel_isEqual(lselector, EOQualifierOperatorEqual) &&
+      !sel_isEqual(lselector, EOQualifierOperatorCaseInsensitiveLike))
     return [self invalidImap4SearchQualifier:@"unexpected qualifier 5"];
   
   [search appendString:@"HEADER "];

--- a/sope-mime/NGImap4/EOSortOrdering+IMAPAdditions.m
+++ b/sope-mime/NGImap4/EOSortOrdering+IMAPAdditions.m
@@ -68,8 +68,8 @@ static NSArray *AllowedSortKeys = nil;
   /* check selector */
   
   sel = [self selector];
-  if (sel_eq(sel, EOCompareDescending) ||
-      sel_eq(sel, EOCompareCaseInsensitiveDescending)) {
+  if (sel_isEqual(sel, EOCompareDescending) ||
+      sel_isEqual(sel, EOCompareCaseInsensitiveDescending)) {
     return [@"REVERSE " stringByAppendingString:lkey];
   }
   // TODO: check other selectors whether they make sense instead of silent acc.

--- a/sope-mime/NGImap4/NGImap4Folder.m
+++ b/sope-mime/NGImap4/NGImap4Folder.m
@@ -702,8 +702,8 @@ static int FetchNewUnseenMessagesInSubFoldersOnDemand = -1;
       }
       muids = [[NSMutableArray alloc] initWithCapacity:255];
 
-      if (sel_eq([so selector], EOCompareAscending) ||
-          sel_eq([so selector], EOCompareCaseInsensitiveAscending)) {
+      if (sel_isEqual([so selector], EOCompareAscending) ||
+          sel_isEqual([so selector], EOCompareCaseInsensitiveAscending)) {
         qual1 = UnseenQual;
         if (_unseen)
           qual2 = nil;

--- a/sope-mime/NGImap4/imCommon.h
+++ b/sope-mime/NGImap4/imCommon.h
@@ -37,18 +37,6 @@
 #include <NGMime/NGMime.h>
 #include <NGMail/NGMail.h>
 
-#if NeXT_RUNTIME || APPLE_RUNTIME
-#  ifndef sel_eq
-#    define sel_eq(__A__,__B__) (__A__==__B__)
-#  endif
-#endif
-
-#if __GNU_LIBOBJC__ >= 20100911
-#  ifndef sel_eq
-#    define sel_eq(__A__,__B__) sel_isEqual(__A__,__B__)
-#  endif
-#endif
-
 @interface NSObject(NGImap4_OSXHacks)
 - (void)subclassResponsibility:(SEL)_acmd;
 - (void)notImplemented:(SEL)_acmd;

--- a/sope-mime/NGMime/common.h
+++ b/sope-mime/NGMime/common.h
@@ -36,12 +36,6 @@
 
 #include "NGMimeType.h"
 
-#if !GNU_RUNTIME
-#  ifndef sel_eq
-#    define sel_eq(__A__, __B__) (__A__==__B__)
-#  endif
-#endif
-
 @interface NSObject(OSXHacks)
 - (void)subclassResponsibility:(SEL)_acmd;
 - (void)notImplemented:(SEL)_acmd;


### PR DESCRIPTION
Stage 8: *CAUTION*

I have scrapped my original patches that descretely fix build errors on FreeBSD (or rather libobjc2). SOPE is riddled with messy runtime compatability definitions, dating back a long time. I'm talking about 'sel_eq', 'sel_get_name', 'objc_malloc', 'objc_free' etc. There was lots of ugly, inconsistent and nonsensical #if's and #ifdefs for all the different brands and ages of Objective C runtimes.

So, I cleaned up all this stuff in the common.h header files, and used only the modern calls throughout the implementation code. But of course, I was worried about the compatability with the various platforms and older runtimes. So I installed RHEL 5.11 in VirtualBox and managed to build SOPE from my github fork. It worked like a charm!

So, the GNUstep Runtime (libobjc2) and the GCC Runtime (libobjc) >= 4.1.2 build successfully with all my changes up to Stage 8. But I have not tested on any Apple/NeXT Runtimes (Mac OS X), since I don't have access to OS X. According to David Chisnall, it should be OK to use the same modern calls that work in libobjc2.

If the support needs to go back further, and the modern calls are not OK. Then I can add back some much neater, consolidated compatability definitions. I suggest each common.h header file include a project wide header file called runtime_compat.h. Then the runtime specific substitutions could all go in one place.

There is potential for much more, similar, cleanup in SOPE.