### PR TITLE
Stage 9 of clang compiler warning patches.

### DIFF
--- a/sope-appserver/NGObjWeb/NSObject+WO.m
+++ b/sope-appserver/NGObjWeb/NSObject+WO.m
@@ -259,7 +259,7 @@ IMP WOGetKVCGetMethod(id object, NSString *_key) {
   if (object == nil) return NULL;
   if (_key   == nil) return NULL;
 
-#if GNU_RUNTIME && !(defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911))
+#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ < 20100911))
   {
     unsigned keyLen;
     char     *buf;
@@ -317,7 +317,7 @@ id WOGetKVCValueUsingMethod(id object, NSString *_key) {
       return nil;
     free(buf); buf = NULL;
   }
-#if GNUSTEP_BASE_LIBRARY
+#if GNUSTEP_BASE_LIBRARY && !defined(__GNUSTEP_RUNTIME__)
   if (!__objc_responds_to(object, getSel))
     return nil;
 #endif

--- a/sope-appserver/NGObjWeb/SoObjects/SoSecurityException.h
+++ b/sope-appserver/NGObjWeb/SoObjects/SoSecurityException.h
@@ -35,8 +35,9 @@
 
 + (id)securityExceptionOnObject:(id)_object
   withAuthenticator:(id)_auth
-  andManager:(id)_manager;
-- (id)initWithObject:(id)_object authenticator:(id)_auth manager:(id)_manager;
+  andManager:(id)_manager
+  reason:(NSString *)_r;
+- (id)initWithObject:(id)_object authenticator:(id)_auth manager:(id)_manager reason:(NSString *)_reason;
 
 - (SoSecurityManager *)securityManager;
 - (id)authenticator;

--- a/sope-appserver/NGObjWeb/SoObjects/SoSecurityException.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoSecurityException.m
@@ -28,17 +28,19 @@
 + (id)securityExceptionOnObject:(id)_o 
   withAuthenticator:(id)_a 
   andManager:(id)_m 
+  reason:(NSString *)_r
 {
   return [[[self alloc] 
-	    initWithObject:_o authenticator:_a manager:_m] autorelease];
+	    initWithObject:_o authenticator:_a manager:_m reason:_r] autorelease];
 }
-- (id)initWithObject:(id)_object authenticator:(id)_auth manager:(id)_manager {
+- (id)initWithObject:(id)_object authenticator:(id)_auth manager:(id)_manager reason:(NSString *)_reason {
   NSString *n, *r;
   
   if ((n = [self name]) == nil)
     n = NSStringFromClass([self class]);
-  if ((r = [self reason]) == nil)
-    r = @"generic security exception";
+  if ((r = _reason) == nil)
+    if ((r = [self reason]) == nil)
+      r = @"generic security exception";
   
   if ((self = [super initWithName:n reason:r userInfo:nil])) {
     self->object          = [_object  retain];

--- a/sope-appserver/NGObjWeb/SoObjects/SoSecurityManager.m
+++ b/sope-appserver/NGObjWeb/SoObjects/SoSecurityManager.m
@@ -74,11 +74,16 @@ static int debugOn = -1;
 
 - (NSException *)makeExceptionForObject:(id)_obj reason:(NSString *)_r {
   NSException *e;
+  NSString *r;
   if (_obj == nil) return nil;
+  if ([_r length] <= 0)
+    r = nil;
+  else
+    r = _r;
   e = [SoAccessDeniedException securityExceptionOnObject:_obj
 			       withAuthenticator:nil
-			       andManager:self];
-  if ([_r length] > 0) [e setReason:_r];
+			       andManager:self
+			       reason:_r];
   return e;
 }
 
@@ -264,7 +269,8 @@ static int debugOn = -1;
 				    withAuthenticator:
 				      [self authenticatorInContext:_ctx 
 					    object:_object]
-				    andManager:self];
+				    andManager:self
+				    reason:nil];
   }
   
   [self debugWithFormat:@"  got user: %@)", user];
@@ -319,7 +325,8 @@ static int debugOn = -1;
                                       withAuthenticator:
                                         [self authenticatorInContext:_ctx
                                               object:_object]
-                                      andManager:self];
+                                      andManager:self
+                                      reason:nil];
     }
     else {
       /* 

--- a/sope-appserver/NGObjWeb/SoObjects/common.h
+++ b/sope-appserver/NGObjWeb/SoObjects/common.h
@@ -23,6 +23,5 @@
 #include <NGExtensions/NGExtensions.h>
 
 @interface NSException(SoObjects_setUserInfo)
-- (id)setReason:(NSString *)_reason;
 - (id)setUserInfo:(NSDictionary *)_userInfo;
 @end

--- a/sope-appserver/NGObjWeb/Templates/WOHTMLParser.m
+++ b/sope-appserver/NGObjWeb/Templates/WOHTMLParser.m
@@ -86,9 +86,9 @@ static BOOL  useUTF8 = NO;
 
 /* callbacks */
 
-- (NSException *)_makeSyntaxErrorException {
+- (NSException *)_makeSyntaxErrorException:(NSString *)_reason {
   return [NSException exceptionWithName:@"SyntaxError"
-                      reason:@"template syntax error"
+                      reason:_reason
                       userInfo:nil];
 }
 
@@ -221,7 +221,6 @@ static NSException *_makeHtmlException(NSException *_exception,
     // error resulted from a previous error (exception already set)
     return _exception;
   
-  exception = [self _makeSyntaxErrorException];
 
   if (atEof)
     _text = [@"Unexpected end: " stringByAppendingString:[_text stringValue]];
@@ -229,8 +228,8 @@ static NSException *_makeHtmlException(NSException *_exception,
     _text = [StrClass stringWithFormat:@"Syntax error in line %i: %@",
                       numLines, _text];
   }
-  
-  [exception setReason:_text];
+
+  exception = [self _makeSyntaxErrorException:_text];
 
   /* user info */
   {

--- a/sope-appserver/NGObjWeb/Templates/common.h
+++ b/sope-appserver/NGObjWeb/Templates/common.h
@@ -33,6 +33,5 @@
           __PRETTY_FUNCTION__, __LINE__];
 
 @interface NSException(NGObjWeb_Templates_setUserInfo)
-- (id)setReason:(NSString *)_reason;
 - (id)setUserInfo:(NSDictionary *)_userInfo;
 @end

--- a/sope-appserver/NGObjWeb/common.h
+++ b/sope-appserver/NGObjWeb/common.h
@@ -89,7 +89,6 @@
 #endif
 
 @interface NSException(setUserInfo)
-- (id)setReason:(NSString *)_reason;
 - (id)setUserInfo:(NSDictionary *)_userInfo;
 @end
 

--- a/sope-core/NGExtensions/FdExt.subproj/NGPropertyListParser.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NGPropertyListParser.m
@@ -43,7 +43,6 @@
 
 @interface NSException(UsedPrivates) /* may break on Panther? */
 - (void)setUserInfo:(NSDictionary *)_ui;
-- (void)setReason:(NSString *)_reason;
 @end
 
 static NSString     *_parseString (NSZone *_zone, const unsigned char *_buffer,

--- a/sope-core/NGExtensions/FdExt.subproj/NSException+misc.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSException+misc.m
@@ -90,28 +90,6 @@
 
 @end /* NSException(NGMiscellaneous) */
 
-#if COCOA_Foundation_LIBRARY || NeXT_Foundation_LIBRARY
-
-@implementation NSException (NGLibFoundationCompatibility)
-- (void)setReason:(NSString *)_reason {
-  [_reason retain];
-  [self->reason release];
-  self->reason = _reason;
-}
-@end
-
-#elif GNUSTEP_BASE_LIBRARY
-
-@implementation NSException (NGLibFoundationCompatibility)
-- (void)setReason:(NSString *)_reason {
-  [_reason retain];
-  [self->_e_reason release];
-  self->_e_reason = _reason;
-}
-@end
-
-#endif
-
 void __link_NGExtensions_NSExceptionMisc() {
   __link_NGExtensions_NSExceptionMisc();
 }

--- a/sope-core/NGExtensions/NGBundleManager.m
+++ b/sope-core/NGExtensions/NGBundleManager.m
@@ -1998,13 +1998,17 @@ static BOOL debugLanguageLookup = NO;
 	   "<%s %p fullPath: %s infoDictionary: %p loaded=%s>",
 #if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) 
 	   (char*)class_getName([self class]),
+	   self,
+	   [[self bundlePath] cString],
+	   [self infoDictionary],
+	   [self isLoaded] ? "yes" : "no");
 #else
 	   (char*)object_get_class_name(self),
-#endif
 	   self,
 	   [[self bundlePath] cString],
 	   [self infoDictionary], 
-	   self->_codeLoaded ? "yes" : "no");
+	   self->codeLoaded ? "yes" : "no");
+#endif
   
   return [NSString stringWithCString:buffer];
 }

--- a/sope-core/NGExtensions/NGBundleManager.m
+++ b/sope-core/NGExtensions/NGBundleManager.m
@@ -1996,20 +1996,12 @@ static BOOL debugLanguageLookup = NO;
   
   sprintf (buffer,
 	   "<%s %p fullPath: %s infoDictionary: %p loaded=%s>",
-#if (defined(__GNU_LIBOBJC__) && (__GNU_LIBOBJC__ >= 20100911)) || defined(APPLE_RUNTIME) || defined(__GNUSTEP_RUNTIME__) 
 	   (char*)class_getName([self class]),
 	   self,
 	   [[self bundlePath] cString],
 	   [self infoDictionary],
 	   [self isLoaded] ? "yes" : "no");
-#else
-	   (char*)object_get_class_name(self),
-	   self,
-	   [[self bundlePath] cString],
-	   [self infoDictionary], 
-	   self->codeLoaded ? "yes" : "no");
-#endif
-  
+
   return [NSString stringWithCString:buffer];
 }
 #endif

--- a/sope-core/NGExtensions/NGExtensions/NSException+misc.h
+++ b/sope-core/NGExtensions/NGExtensions/NSException+misc.h
@@ -55,13 +55,6 @@
 @end
 
 
-#if COCOA_Foundation_LIBRARY || GNUSTEP_BASE_LIBRARY
-@interface NSException (NGLibFoundationCompatibility)
-- (void)setReason:(NSString *)_reason;
-@end
-#endif
-
-
 /*
   The following macros are for use of locks together with exception handling.
   A synchronized block is properly 'unlocked' even if an exception occures.

--- a/sope-gdl1/GDLAccess/EOFault.h
+++ b/sope-gdl1/GDLAccess/EOFault.h
@@ -9,6 +9,13 @@
 
 @class EOFaultHandler;
 
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+#if __has_attribute(objc_root_class)
+__attribute__((objc_root_class))
+#endif
 @interface EOFault
 {
   Class          isa;

--- a/sope-gdl1/PostgreSQL/PostgreSQL72DataTypeMappingException.m
+++ b/sope-gdl1/PostgreSQL/PostgreSQL72DataTypeMappingException.m
@@ -29,12 +29,15 @@
 #if !LIB_FOUNDATION_LIBRARY
 @interface PostgreSQL72DataTypeMappingException(Privates)
 - (void)setName:(NSString *)_name;
-- (void)setReason:(NSString *)_reason;
 - (void)setUserInfo:(NSDictionary *)_ui;
 @end
 #endif
 
 @implementation PostgreSQL72DataTypeMappingException
+
+/*
+// Unused method: setReason method call is bad and has been removed
+// from NSException_misc.m because it uses IVARS. Exception reasons should be immutable.
 
 - (id)initWithObject:(id)_obj
   forAttribute:(EOAttribute *)_attr
@@ -64,6 +67,7 @@
                                     nil]];
   return self;
 }
+*/ // END unused method (initWithObject)
 
 @end /* PostgreSQL72DataTypeMappingException */
 

--- a/sope-gdl1/PostgreSQL/PostgreSQL72Values.h
+++ b/sope-gdl1/PostgreSQL/PostgreSQL72Values.h
@@ -38,11 +38,13 @@
 
 @interface PostgreSQL72DataTypeMappingException : PostgreSQL72Exception
 
+/*
 - (id)initWithObject:(id)_obj
   forAttribute:(EOAttribute *)_attr
   andPostgreSQLType:(NSString *)_dt
   inChannel:(PostgreSQL72Channel *)_channel;
 
+*/
 @end
 
 @protocol PostgreSQL72Values


### PR DESCRIPTION
Stage 9:

These fix build errors on FreeBSD and/or Clang and/or libobjc2.

They address the following issues:
(i) Runtime compatability logic in #if statements needs support for \_\_GNUSTEP_RUNTIME\_\_.
(ii) Fix build error by setting attribute for root class in EOFault.h.
(iii) Removed need for EXPOSE\_?\_IVARS in NGBundleManager.m by using isLoaded instead of \_codeLoaded.
(iv) Removed need for EXPOSE\_?\_IVARS in NSException+misc.h by removing the bad method 'setReason'. All uses of this method have been removed by setting the exceptions' 'reason' at init time, as it should be. An exceptions' 'reason' should be immutable, thus why there is no safe setter for it in NSException.

**Setting an ivar is not acceptable, and will be impossible in future versions of GNUstep Runtime.**