### PR TITLE
Revert "Close all file descriptors on daemon start"

### DIFF
--- a/sope-appserver/NGObjWeb/WOWatchDogApplicationMain.m
+++ b/sope-appserver/NGObjWeb/WOWatchDogApplicationMain.m
@@ -982,7 +982,7 @@ int WOWatchDogApplicationMain
   NSAutoreleasePool *pool;
   NSUserDefaults *ud;
   NSString *logFile, *nsPidFile;
-  int rc, i;
+  int rc;
   pid_t childPid;
   NSProcessInfo *processInfo;
   Class WOAppClass;
@@ -1010,11 +1010,6 @@ int WOWatchDogApplicationMain
     logFile = [NSString stringWithFormat: @"/var/log/%@/%@.log",
                         [processInfo processName],
                         [processInfo processName]];
-
-  /* Close all open file descriptors */
-  for (i = getdtablesize(); i >= 3; --i)
-    close(i);
-  freopen("/dev/null", "a", stdin);
   if (![logFile isEqualToString: @"-"]) {
     freopen([logFile cString], "a", stdout);
     freopen([logFile cString], "a", stderr);


### PR DESCRIPTION
Reverts inverse-inc/sope#4

See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=803197 for details.

We might re-integrate this change later on, when libldap is fixed.