### PR TITLE
Link libSBJson with BASE_LIBS to prevent undefined symbols

### DIFF
--- a/sope-json/SBJson/Classes/GNUmakefile
+++ b/sope-json/SBJson/Classes/GNUmakefile
@@ -25,6 +25,8 @@ SBJson_OBJC_FILES = \
 	SBJsonParser.m \
 	SBJsonWriter.m
 
+SBJson_LIBRARIES_DEPEND_UPON += $(BASE_LIBS)
+
 -include GNUmakefile.preamble
 include $(GNUSTEP_MAKEFILES)/library.make
 -include GNUmakefile.postamble


### PR DESCRIPTION
Because there is no GNUmakefile.preamble for sope-json/SBJson/Classes
libSBJson is not linked with BASE_LIBS (libgnustep-base an so on).
Our build system checks for undefined symbols in libraries and found
in libSBJson.so.2.3.1:

Verifying ELF objects in /usr/src/tmp/sope-buildroot (arch=normal,fhs=normal,lfs=relaxed,lint=relaxed,rpath=normal,stack=normal,textrel=normal,unresolved=normal)
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSMutableArray
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSDictionary
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSError
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSObject
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSAssertionHandler
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSString
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSArray
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSNull
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSNumber
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSMutableDictionary
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSMutableString
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSDecimalNumber
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_class_name_NSMutableCharacterSet
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: NSLocalizedDescriptionKey
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: NSUnderlyingErrorKey
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: objc_slot_lookup_super
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: __objc_exec_class
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: NSLog
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: objc_lookup_class
verify-elf: ERROR: ./usr/lib64/libSBJson.so.2.3.1: undefined symbol: objc_msgSend

This patch allows libSBJson links with BASE_LIBS.
