### PR TITLE
Fix compilation with mysql

### DIFF
--- a/sope-gdl1/MySQL/GNUmakefile.preamble
+++ b/sope-gdl1/MySQL/GNUmakefile.preamble
@@ -33,12 +33,12 @@ endif
 
 MySQL_BUNDLE_LIBS += \
 	-lGDLAccess	\
-	`mysql_config --libs`
+	$(shell mysql_config --libs)
 
 MySQLD_BUNDLE_LIBS += \
 	-lGDLAccess	\
 	-lEOControl	\
-	`mysql_config --libs`
+	$(shell mysql_config --libs)
 
 gdltest_TOOL_LIBS += \
 	-lGDLAccess	\
@@ -46,14 +46,15 @@ gdltest_TOOL_LIBS += \
 
 # set compile flags and go
 
-ADDITIONAL_CFLAGS += `mysql_config --cflags`
+ADDITIONAL_CFLAGS += $(shell mysql_config --cflags)
 
 ADDITIONAL_INCLUDE_DIRS += \
 	-I../GDLAccess -I.. -I$(SOPE_ROOT)
 
 ADDITIONAL_INCLUDE_DIRS += \
 	-I$(SOPE_ROOT)/sope-core/		\
-	-I$(SOPE_ROOT)/sope-core/NGExtensions
+	-I$(SOPE_ROOT)/sope-core/NGExtensions   \
+	$(shell mysql_config --include)
 
 
 # dependencies


### PR DESCRIPTION
Original patch by Russell Knighton <russell@annunaki2k2.co.uk>
Gentoo bug: https://bugs.gentoo.org/show_bug.cgi?id=566138

Compilation fails with mysql:
```
x86_64-pc-linux-gnu-gcc NSCalendarDate+MySQL4Val.m -c \
      -MMD -MP -DGNUSTEP -DGNUSTEP_BASE_LIBRARY=1 -DGNU_GUI_LIBRARY=1 -DGNU_RUNTIME=1 -DGNUSTEP_BASE_LIBRARY=1 -fno-strict-aliasing -pthread -fPIC -Wall -DGSWARN -DGSDIAGNOSE -Wno-import -m
arch=corei7-avx -O2 -pipe -fno-stack-protector -fgnu-runtime -fconstant-string-class=NSConstantString -I../GDLAccess -I.. -I../.. -I../../sope-core/ -I../../sope-core/NGExtensions -I. -I/va
r/tmp/portage/gnustep-libs/sope-2.3.2/work/GNUstep/Library/Headers -I/usr/local/include -I/usr/include \
       -o obj/MySQL.obj/NSCalendarDate+MySQL4Val.m.o
In file included from /usr/include/mysql/mysql.h:64:0,
                 from MySQL4Values.h:36,
                 from MySQL4Values.m:26:
/usr/include/mysql/mysql/client_plugin.h:103:38: fatal error: mysql/plugin_auth_common.h: No such file or directory
 #include <mysql/plugin_auth_common.h>
                                      ^
compilation terminated.
/usr/share/GNUstep/Makefiles/rules.make:479: recipe for target 'obj/MySQL.obj/MySQL4Values.m.o' failed
gmake[5]: *** [obj/MySQL.obj/MySQL4Values.m.o] Error 1
gmake[5]: *** Waiting for unfinished jobs....
In file included from /usr/include/mysql/mysql.h:64:0,
                 from MySQL4Values.h:36,
                 from MySQL4Adaptor.m:30:
/usr/include/mysql/mysql/client_plugin.h:103:38: fatal error: mysql/plugin_auth_common.h: No such file or directory
 #include <mysql/plugin_auth_common.h>
                                      ^
compilation terminated.
```