### PR TITLE
Add -O2 compilation by default and -g debug info

### DIFF
--- a/configure
+++ b/configure
@@ -426,6 +426,7 @@ genConfigMake() {
     cfgwrite "${MAKE_ASSI}";
   done
   cfgwrite "LIBRARY_COMBO=$LIBRARY_COMBO"
+  cfgwrite "include \${SOPE_ROOT}/general.make"
   cfgwrite ""
 }
 

--- a/general.make
+++ b/general.make
@@ -1,0 +1,29 @@
+# Macros that allow testing for GCC flag existence
+try-run = $(shell set -e;                      \
+	TMP="/tmp/SOPE-gcc-flags-check.$$$$.tmp";  \
+	TMPO="/tmp/SOPE-gcc-flags-check.$$$$.o";   \
+	if ($(1)) >/dev/null 2>&1;                 \
+	then echo "$(2)";                          \
+	else echo "$(3)";                          \
+	fi;                                        \
+	rm -f "$$TMP" "$$TMPO")
+
+cc-option = $(call try-run,\
+	$(CC) $(1) -c -x c /dev/null -o "$$TMP",$(1),$(2))
+
+# Use GCC level 2 optimization by default
+# Might be overridden below
+ADDITIONAL_OBJCFLAGS=-O2
+ifeq ($(test-uninitialized),yes)
+ifeq ($(debug),yes)
+ADDITIONAL_OBJCFLAGS=-O0
+else
+ADDITIONAL_OBJCFLAGS=-Wuninitialized
+endif
+endif
+# Ensure we store in the ELF files minimal debugging
+# information plus the compiler flags used; that can
+# be afterwards read with:
+# readelf -p .GCC.command.line /path/to/elf_file
+ADDITIONAL_OBJCFLAGS += -g $(call cc-option,-frecord-gcc-switches)
+


### PR DESCRIPTION
Also when possible, store GCC command-line switches
in the binaries for easier debugging.

Inspired by the way SOGo does it, using a general.make file.