### PR TITLE
Convert 'configure' shebang back to /bin/sh for platform compatability

### DIFF
--- a/configure
+++ b/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #
 # Note: When adding make options to this script, ensure that the source still


### PR DESCRIPTION
Using /bin/sh instead does not cause any errors or issues in my usage on FreeBSD.