### PR TITLE
Revert "feat(core): Peer verification on TLS connections"

### DIFF
--- a/sope-appserver/NGObjWeb/WOHTTPConnection.m
+++ b/sope-appserver/NGObjWeb/WOHTTPConnection.m
@@ -218,11 +218,10 @@ static BOOL logStream = NO;
     [self debugWithFormat:@"got no address for connect .."];
     return NO;
   }
-
+  
   NS_DURING {
     self->socket = self->useSSL
-      ? [SSLSocketClass socketConnectedToAddress:address
-                                      onHostName: [self->url host]]
+      ? [SSLSocketClass socketConnectedToAddress:address]
       : [NGActiveSocket socketConnectedToAddress:address];
   }
   NS_HANDLER {

--- a/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
+++ b/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
@@ -1,7 +1,6 @@
 /*
   Copyright (C) 2000-2005 SKYRIX Software AG
   Copyright (C) 2011 Jeroen Dekkers <jeroen@dekkers.ch>
-  Copyright (C) 2020 Nicolas Höft
 
   This file is part of SOPE.
 
@@ -23,13 +22,11 @@
 #ifndef __NGNet_NGActiveSSLSocket_H__
 #define __NGNet_NGActiveSSLSocket_H__
 
-#import <NGStreams/NGSocketProtocols.h>
 #include <NGStreams/NGActiveSocket.h>
 #include "../config.h"
 
 @interface NGActiveSSLSocket : NGActiveSocket
 {
-@protected
 #ifdef HAVE_GNUTLS
   void *cred; /* real type: gnutls_certificate_credentials_t */
   void *session; /* real type: gnutls_session_t */
@@ -38,15 +35,10 @@
   void *ssl;   /* real type: SSL */
   void *sbio;  /* real type: BIO (basic input/output) */
 #endif
-  NSString *hostName;
 }
-+ (id) socketConnectedToAddress: (id<NGSocketAddress>) _address
-                  onHostName: (NSString *) hostName;
-
-- (id)initWithDomain:(id<NGSocketDomain>)_domain
-      onHostName: (NSString *)_hostName;
 
 - (BOOL) startTLS;
+
 @end
 
 #endif /* __NGNet_NGActiveSSLSocket_H__ */

--- a/sope-mime/NGImap4/NGSieveClient.m
+++ b/sope-mime/NGImap4/NGSieveClient.m
@@ -291,17 +291,18 @@ static BOOL     debugImap4         = NO;
   // If we're using TLS, we start it here
   if (self->useTLS)
     {
+      Class socketClass;
       NSDictionary *d;
       
       d = [self normalizeResponse:[self processCommand: @"STARTTLS"]];
-
-      if ([[d valueForKey:@"result"] boolValue])
+      socketClass = NSClassFromString(@"NGActiveSSLSocket");
+      
+      if ([[d valueForKey:@"result"] boolValue] && socketClass)
 	{
 	  int oldopts;
 	  id o;
-
-	  o = [[NGActiveSSLSocket alloc] initWithDomain: [self->address domain]
-	                                     onHostName: [(NGInternetSocketAddress *)self->address hostName]];
+	  
+	  o = [[socketClass alloc] initWithDomain: [self->address domain]];
 	  [o setFileDescriptor: [(NGSocket*)self->socket fileDescriptor]];
 	  
 	  // We remove the NON-BLOCKING I/O flag on the file descriptor, otherwise


### PR DESCRIPTION
Reverts inverse-inc/sope#52

This code causes too many issues on a lot of OSes:

/usr/share/GNUstep/Makefiles/rules.make:468: recipe for target 'obj/libNGStreams.obj/NGActiveSSLSocket.m.o' failed
make[6]: *** [obj/libNGStreams.obj/NGActiveSSLSocket.m.o] Error 1
/usr/share/GNUstep/Makefiles/Instance/library.make:275: recipe for target 'internal-library-all_' failed
make[5]: *** [internal-library-all_] Error 2
/usr/share/GNUstep/Makefiles/Master/rules.make:298: recipe for target 'libNGStreams.all.library.variables' failed
make[4]: *** [libNGStreams.all.library.variables] Error 2
/usr/share/GNUstep/Makefiles/Master/library.make:37: recipe for target 'internal-all' failed
make[3]: *** [internal-all] Error 2
make[3]: Leaving directory '/root/src/sope-4.9/sope-core/NGStreams'
/usr/share/GNUstep/Makefiles/Master/serial-subdirectories.make:53: recipe for target 'internal-all' failed
make[2]: *** [internal-all] Error 2
make[2]: Leaving directory '/root/src/sope-4.9/sope-core'
/usr/share/GNUstep/Makefiles/Master/serial-subdirectories.make:53: recipe for target 'internal-all' failed
make[1]: *** [internal-all] Error 2
make[1]: Leaving directory '/root/src/sope-4.9'
debian/rules:61: recipe for target 'build-stamp' failed
make: *** [build-stamp] Error 2
dpkg-buildpackage: error: debian/rules build gave error exit status 2
debuild: fatal error at line 1376:
dpkg-buildpackage -rfakeroot -D -us -uc failed
