### PR TITLE
feat(core): Implement optional TLS validation

### DIFF
--- a/sope-appserver/NGObjWeb/WOHTTPConnection.m
+++ b/sope-appserver/NGObjWeb/WOHTTPConnection.m
@@ -25,6 +25,7 @@
 #include <NGObjWeb/WOResponse.h>
 #include <NGObjWeb/WOCookie.h>
 #include <NGObjWeb/WORunLoop.h>
+#include <NGStreams/NGActiveSSLSocket.h>
 #include <NGStreams/NGStreams.h>
 #include <NGStreams/NGCTextStream.h>
 #include <NGStreams/NGBufferedStream.h>
@@ -71,7 +72,7 @@ static BOOL logStream = NO;
   static BOOL didInit = NO;
   if (didInit) return;
   didInit = YES;
-    
+
   useSimpleParser = [ud boolForKey:@"WOHTTPConnectionUseSimpleParser"];
   proxyServer     = [ud stringForKey:@"WOProxyServer"];
   noProxy         = [ud arrayForKey:@"WONoProxySuffixes"];
@@ -88,7 +89,7 @@ static BOOL logStream = NO;
   ps = [self proxyServer];
   if ([ps length] == 0)
     return nil;
-  
+
   return [NSURL URLWithString:ps];
 }
 + (NSArray *)noProxySuffixes {
@@ -100,7 +101,7 @@ static BOOL logStream = NO;
     self->url      = [_url retain];
     self->useSSL   = [[_url scheme] isEqualToString:@"https"];
     self->useProxy = [_url shouldUseWOProxyServer];
-    
+
     if (self->useSSL) {
       static BOOL didCheck = NO;
       if (!didCheck) {
@@ -114,7 +115,7 @@ static BOOL logStream = NO;
 
 - (id)initWithURL:(id)_url {
   NSURL *lurl;
-  
+
   /* create an NSURL object if necessary */
   lurl = [_url isKindOfClass:[NSURL class]]
     ? _url
@@ -130,13 +131,13 @@ static BOOL logStream = NO;
   return [self initWithNSURL:lurl];
 }
 
-- (id)initWithHost:(NSString *)_hostName onPort:(unsigned int)_port 
+- (id)initWithHost:(NSString *)_hostName onPort:(unsigned int)_port
   secure:(BOOL)_flag
 {
   NSString *s;
-  
+
   s = [NSString stringWithFormat:@"http%s://%@:%i/",
-		  _flag ? "s" : "", _hostName, 
+		  _flag ? "s" : "", _hostName,
 		  _port == 0 ? (_flag?443:80) : _port];
   return [self initWithURL:s];
 }
@@ -168,7 +169,7 @@ static BOOL logStream = NO;
 - (NSString *)loggingPrefix {
   /* improve perf ... */
   if (self->url) {
-    return [NSString stringWithFormat:@"WOHTTP[0x%p]<%@>", 
+    return [NSString stringWithFormat:@"WOHTTP[0x%p]<%@>",
 		       self, [self->url absoluteString]];
   }
   else
@@ -185,14 +186,14 @@ static BOOL logStream = NO;
 
 - (BOOL)_connect {
   id<NGSocketAddress> address;
-  
+
   [self _disconnect];
-  
+
 #if DEBUG
   NSAssert(self->socket == nil, @"socket still available after disconnect");
   NSAssert(self->io == nil,     @"IO stream still available after disconnect");
 #endif
-  
+
   if (self->useSSL) {
     if (SSLSocketClass == Nil) {
       /* no SSL support is available */
@@ -204,10 +205,10 @@ static BOOL logStream = NO;
       return NO;
     }
   }
-  
+
   if (self->useProxy) {
     NSURL *purl;
-    
+
     purl = [[self class] proxyServerURL];
     address = [purl socketAddressForURL];
   }
@@ -222,7 +223,7 @@ static BOOL logStream = NO;
   NS_DURING {
     self->socket = self->useSSL
       ? [SSLSocketClass socketConnectedToAddress:address
-                                      onHostName: [self->url host]]
+                                  withVerifyMode: TLSVerifyDefault]
       : [NGActiveSocket socketConnectedToAddress:address];
   }
   NS_HANDLER {
@@ -234,26 +235,26 @@ static BOOL logStream = NO;
     self->socket = nil;
   }
   NS_ENDHANDLER;
-  
+
   if (self->socket == nil) {
     [self debugWithFormat:@"socket is not setup: %@", [self lastException]];
     return NO;
   }
-  
+
   if (![self->socket isConnected]) {
     self->socket = nil;
     [self debugWithFormat:@"socket is not connected .."];
     return NO;
   }
-  
+
   self->socket = [self->socket retain];
-  
+
   [(NGActiveSocket *)self->socket setSendTimeout:[self sendTimeout]];
   [(NGActiveSocket *)self->socket setReceiveTimeout:[self receiveTimeout]];
-  
+
   if (self->socket != nil) {
     NGBufferedStream *bStr;
-    
+
     bStr = [NGBufferedStream alloc]; // keep gcc happy
     bStr = [bStr initWithSource:self->socket];
     if (logStream) {
@@ -262,24 +263,24 @@ static BOOL logStream = NO;
     }
     else
       self->log = nil;
-    
+
     self->io = [NGCTextStream alloc]; // keep gcc happy
     self->io = [self->io initWithSource:
 		      (id)(self->log != nil ? self->log : (id)bStr)];
     [bStr release]; bStr = nil;
   }
-  
+
   return YES;
 }
 - (void)_disconnect {
   [self->log release]; self->log = nil;
   [self->io  release]; self->io  = nil;
-  
+
   NS_DURING
     (void)[self->socket shutdown];
   NS_HANDLER {}
   NS_ENDHANDLER;
-  
+
   [self->socket release]; self->socket = nil;
 }
 
@@ -287,7 +288,7 @@ static BOOL logStream = NO;
 
 - (void)logRequest:(WORequest *)_response data:(NSData *)_data {
   if (_data == nil) return;
-  
+
 #if 1
   NSLog(@"request is\n");
   fflush(stderr);
@@ -299,7 +300,7 @@ static BOOL logStream = NO;
 }
 - (void)logResponse:(WOResponse *)_response data:(NSData *)_data {
   if (_data == nil) return;
-  
+
 #if 1
   NSLog(@"response is\n");
   fflush(stderr);
@@ -315,10 +316,10 @@ static BOOL logStream = NO;
 - (BOOL)sendRequest:(WORequest *)_request {
   NSData *content;
   BOOL isok = YES;
-  
+
   if (doDebug)
     [self debugWithFormat:@"send request: %@", _request];
-  
+
   if (![self->socket isConnected]) {
     if (![self _connect]) {
       /* could not connect */
@@ -328,16 +329,16 @@ static BOOL logStream = NO;
     }
     /* now connected */
   }
-  
+
   content = [_request content];
-  
+
   /* write request line (eg 'GET / HTTP/1.0') */
   if (doDebug)
     [self debugWithFormat:@"  method: %@", [_request method]];
-  
+
   if (isok) isok = [self->io writeString:[_request method]];
   if (isok) isok = [self->io writeString:@" "];
-  
+
   if (self->useProxy) {
     if (isok)
       // TODO: check whether this produces a '//' (may need to strip uri)
@@ -345,13 +346,13 @@ static BOOL logStream = NO;
     [self debugWithFormat:@"  wrote proxy start ..."];
   }
   if (isok) isok = [self->io writeString:[_request uri]];
-  
+
   if (isok) isok = [self->io writeString:@" "];
   if (isok) isok = [self->io writeString:[_request httpVersion]];
   if (isok) isok = [self->io writeString:@"\r\n"];
 
   /* set content-length header */
-  
+
   if ([content length] > 0) {
     [_request setHeader:[NSString stringWithFormat:@"%d", (int)[content length]]
               forKey:@"content-length"];
@@ -359,20 +360,20 @@ static BOOL logStream = NO;
 
   if ([[self->url scheme] hasPrefix:@"http"]) {
     /* host header */
-    
+
     if (isok) isok = [self->io writeString:@"Host: "];
     if (isok) isok = [self->io writeString:[self hostName]];
     if (isok) isok = [self->io writeString:@"\r\n"];
     [self debugWithFormat:@"  wrote host header: %@", [self hostName]];
   }
-  
+
   /* write request headers */
 
   if (isok) {
     NSEnumerator *fields;
     NSString *fieldName;
     int cnt;
-    
+
     fields = [[_request headerKeys] objectEnumerator];
     cnt = 0;
     while (isok && (fieldName = [fields nextObject])) {
@@ -387,9 +388,9 @@ static BOOL logStream = NO;
 	  /* did already write host ... */
 	  continue;
       }
-      
+
       values = [[_request headersForKey:fieldName] objectEnumerator];
-        
+
       while ((value = [values nextObject]) && isok) {
         if (isok) isok = [self->io writeString:fieldName];
         if (isok) isok = [self->io writeString:@": "];
@@ -400,9 +401,9 @@ static BOOL logStream = NO;
     }
     [self debugWithFormat:@"  wrote %i request headers ...", cnt];
   }
-  
+
   /* write some required headers */
-  
+
   if ([_request headerForKey:@"accept"] == nil) {
     if (isok) isok = [self->io writeString:@"Accept: */*\r\n"];
     [self debugWithFormat:@"  wrote accept header ..."];
@@ -412,22 +413,22 @@ static BOOL logStream = NO;
       static NSString *s = nil;
       if (s == nil) {
 	s = [[NSString alloc] initWithFormat:@"User-Agent: SOPE/%i.%i.%i\r\n",
-			      SOPE_MAJOR_VERSION, SOPE_MINOR_VERSION, 
+			      SOPE_MAJOR_VERSION, SOPE_MINOR_VERSION,
 			      SOPE_SUBMINOR_VERSION];
       }
       isok = [self->io writeString:s];
     }
     [self debugWithFormat:@"  wrote user-agent header ..."];
   }
-  
+
   /* write cookie headers */
-  
+
   if ([[_request cookies] count] > 0 && isok) {
     NSEnumerator *cookies;
     WOCookie     *cookie;
     BOOL         isFirst;
     int cnt;
-    
+
     [self->io writeString:@"set-cookie: "];
     cnt = 0;
     cookies = [[_request cookies] objectEnumerator];
@@ -435,26 +436,26 @@ static BOOL logStream = NO;
     while (isok && (cookie = [cookies nextObject])) {
       if (isFirst) isFirst = NO;
       else if (isok) isok = [self->io writeString:@"; "];
-      
+
       if (isok) isok = [self->io writeString:[cookie stringValue]];
       cnt ++;
     }
     if (isok) isok = [self->io writeString:@"\r\n"];
     [self debugWithFormat:@"  wrote %i cookies ...", cnt];
   }
-  
+
   /* flush request header on socket */
-  
+
   if (isok) isok = [self->io writeString:@"\r\n"];
   if (isok) isok = [self->io flush];
   [self debugWithFormat:@"  flushed HTTP header."];
-  
+
   /* write content */
 
   if ([content length] > 0) {
-    [self debugWithFormat:@"  writing HTTP entity (length=%i).", 
+    [self debugWithFormat:@"  writing HTTP entity (length=%i).",
             [content length]];
-    
+
     if ([content isKindOfClass:[NSString class]]) {
       if (isok) isok = [self->io writeString:(NSString *)content];
     }
@@ -471,22 +472,22 @@ static BOOL logStream = NO;
   else if (doDebug) {
     [self debugWithFormat:@"  no HTTP entity to write ..."];
   }
-  
+
   if (logStream)
     [self logRequest:_request data:[self->log writeLog]];
   [self->log resetWriteLog];
-  
-  [self debugWithFormat:@"=> finished:\n  url:  %@\n  sock: %@", 
+
+  [self debugWithFormat:@"=> finished:\n  url:  %@\n  sock: %@",
           self->url, self->socket];
   if (!isok) {
     ASSIGN(self->lastException, [self->socket lastException]);
     [self->socket shutdown];
     return NO;
   }
-  
+
   if (![self->socket isConnected])
     return NO;
-  
+
   return YES;
 }
 
@@ -500,26 +501,26 @@ static BOOL logStream = NO;
 - (WOResponse *)readResponse {
   /* TODO: split up method */
   WOResponse *response;
-  
+
   *(&response) = nil;
-  
+
   if (self->socket == nil) {
     [self debugWithFormat:@"no socket available for reading response ..."];
     return nil;
   }
-  
+
   [self debugWithFormat:@"parsing response from socket: %@", self->socket];
-  
+
   if (useSimpleParser) {
     WOSimpleHTTPParser *parser;
-    
+
     [self debugWithFormat:@"  using simple HTTP parser ..."];
-    
+
     parser = [[WOSimpleHTTPParser alloc] initWithStream:[self->io source]];
     if (parser == nil)
       return nil;
     parser = [parser autorelease];
-    
+
     if ((response = [parser parseResponse]) == nil) {
       if (doDebug)
         [self debugWithFormat:@"parsing failed: %@", [parser lastException]];
@@ -530,14 +531,14 @@ static BOOL logStream = NO;
     NGHttpResponse *mresponse;
     NGMimeType     *ctype;
     id body;
-    
+
     *(&mresponse) = nil;
-    
+
     if ((parser = [[[NGHttpMessageParser alloc] init] autorelease]) == nil)
       return nil;
-    
+
     [self debugWithFormat:@"  using MIME HTTP parser (complex parser) ..."];
-    
+
     NS_DURING {
       [parser setDelegate:self];
       mresponse = [parser parseResponseFromStream:self->socket];
@@ -545,14 +546,14 @@ static BOOL logStream = NO;
     NS_HANDLER
       [[self handleResponseParsingError:localException] raise];
     NS_ENDHANDLER;
-    
+
     [self debugWithFormat:@"finished parsing response: %@", mresponse];
-    
+
     /* transform parsed MIME response to WOResponse */
-    
+
     body = [mresponse body];
     if (body == nil) body = [NSData data];
-    
+
     response = [[[WOResponse alloc] init] autorelease];
     [response setHTTPVersion:[mresponse httpVersion]];
     [response setStatus:[mresponse statusCode]];
@@ -561,21 +562,21 @@ static BOOL logStream = NO;
                                           mresponse, @"NGMimeResponse",
                                           body,      @"NGMimeBody",
                                           nil]];
-  
+
     { /* check content-type */
       id value;
-      
-      value = [[mresponse valuesOfHeaderFieldWithName:@"content-type"] 
+
+      value = [[mresponse valuesOfHeaderFieldWithName:@"content-type"]
   	                nextObject];
       if (value) {
         NSString *charset;
-        
+
         ctype = [NGMimeType mimeType:[value stringValue]];
         charset = [[ctype valueOfParameter:@"charset"] lowercaseString];
-        
+
         if ([charset length] == 0) {
           /* autodetect charset ... */
-          
+
           if ([[ctype type] isEqualToString:@"text"]) {
             if ([[ctype subType] isEqualToString:@"xml"]) {
               /* default XML encoding is UTF-8 */
@@ -585,27 +586,27 @@ static BOOL logStream = NO;
         }
         else {
           NSStringEncoding enc;
-          
+
           enc = [NGMimeType stringEncodingForCharset:charset];
           [response setContentEncoding:enc];
         }
-        
+
         [response setHeader:[ctype stringValue] forKey:@"content-type"];
-        
+
       }
       else {
         ctype = [NGMimeType mimeType:@"application/octet-stream"];
       }
     }
-  
+
     /* check content */
-    
+
     if ([body isKindOfClass:[NSData class]]) {
       [response setContent:body];
     }
     else if ([body isKindOfClass:[NSString class]]) {
       NSData *data;
-      
+
       data = [body dataUsingEncoding:[response contentEncoding]];
       if (data)
         [response setContent:data];
@@ -614,28 +615,28 @@ static BOOL logStream = NO;
       /* generate data from structured body .. */
       NGMimeBodyGenerator *gen;
       NSData *data;
-      
+
       gen = [[[NGMimeBodyGenerator alloc] init] autorelease];
       data = [gen generateBodyOfPart:body
                   additionalHeaders:nil
                   delegate:self];
       [response setContent:data];
     }
-    
+
     { /* transfer headers */
       NSEnumerator *names;
       NSString     *name;
-      
+
       names = [mresponse headerFieldNames];
       while ((name = [names nextObject])) {
         NSEnumerator *values;
         id           value;
-        
+
         if ([name isEqualToString:@"content-type"])
           continue;
         if ([name isEqualToString:@"set-cookie"])
           continue;
-        
+
         values = [mresponse valuesOfHeaderFieldWithName:name];
         while ((value = [values nextObject])) {
           value = [value stringValue];
@@ -643,16 +644,16 @@ static BOOL logStream = NO;
         }
       }
     }
-    
+
     { /* transfer cookies */
       NSEnumerator *cookies;
       NGHttpCookie *mcookie;
-  
+
       cookies = [mresponse valuesOfHeaderFieldWithName:@"set-cookie"];
-      
+
       while ((mcookie = [cookies nextObject])) {
         WOCookie *woCookie;
-        
+
         if (![mcookie isKindOfClass:[NGHttpCookie class]]) {
           /* parse cookie */
           woCookie = [WOCookie cookieWithString:[mcookie stringValue]];
@@ -672,28 +673,28 @@ static BOOL logStream = NO;
           // could not create cookie
           continue;
         }
-        
+
         [self debugWithFormat:@"adding cookie: %@", woCookie];
-        
+
         [response addCookie:woCookie];
       }
     }
   }
-  
+
   if (logStream)
     [self logResponse:response data:[self->log readLog]];
   [self->log resetReadLog];
-  
+
   if (doDebug)
     [self debugWithFormat:@"processed response: %@", response];
-  
+
   /* check keep-alive */
   {
     NSString *conn;
-    
+
     conn = [response headerForKey:@"connection"];
     conn = [conn lowercaseString];
-    
+
     if ([conn isEqualToString:@"close"]) {
       [self setKeepAliveEnabled:NO];
       [self _disconnect];
@@ -706,7 +707,7 @@ static BOOL logStream = NO;
       [self _disconnect];
     }
   }
-  
+
   return response;
 }
 
@@ -744,16 +745,16 @@ static BOOL logStream = NO;
 
 - (NSString *)description {
   NSMutableString *str;
-  
+
   str = [NSMutableString stringWithCapacity:128];
   [str appendFormat:@"<%@[0x%p]:", NSStringFromClass([self class]), self];
-  
+
   if (self->url)      [str appendFormat:@" url=%@", self->url];
   if (self->useProxy) [str appendString:@" proxy"];
   if (self->useSSL)   [str appendString:@" SSL"];
 
   if (self->socket) [str appendFormat:@" socket=%@", self->socket];
-  
+
   [str appendString:@">"];
   return str;
 }
@@ -764,25 +765,25 @@ static BOOL logStream = NO;
 
 - (id)socketAddressForURL {
   NSString *s;
-  
+
   s = [self scheme];
-  
+
   if ([s isEqualToString:@"http"]) {
     int p;
-    
+
     s = [self host];
     if ([s length] == 0) s = @"localhost";
     p = [[self port] intValue];
-    
+
     return [NGInternetSocketAddress addressWithPort:p == 0 ? 80 : p onHost:s];
   }
   else if ([s isEqualToString:@"https"]) {
     int p;
-    
+
     s = [self host];
     if ([s length] == 0) s = @"localhost";
     p = [[self port] intValue];
-    
+
     return [NGInternetSocketAddress addressWithPort:p == 0 ? 443 : p onHost:s];
   }
   else if ([s isEqualToString:@"unix"] || [s isEqualToString:@"file"]) {
@@ -794,20 +795,20 @@ static BOOL logStream = NO;
 - (BOOL)shouldUseWOProxyServer {
   if ([[self scheme] hasPrefix:@"http"]) {
     NSString *h;
-    
+
     if ((h = [self host]) == nil)
       return NO;
-    
+
     if ([h isEqualToString:@"127.0.0.1"])
       return NO;
     if ([h isEqualToString:@"localhost"])
       return NO;
-    
+
     if ([[WOHTTPConnection proxyServer] length] > 0) {
       NSEnumerator *e;
       NSString *suffix;
       BOOL     useProxy;
-      
+
       useProxy = YES;
       e = [[WOHTTPConnection noProxySuffixes] objectEnumerator];
       while ((suffix = [e nextObject])) {

--- a/sope-core/NGExtensions/FdExt.subproj/NSURL+misc.m
+++ b/sope-core/NGExtensions/FdExt.subproj/NSURL+misc.m
@@ -35,16 +35,16 @@ static BOOL debugURLProcessing = NO;
       /dbd.woa/so/localhost
   */
   NSString *p;
-  
+
   if ((p = [self path]) == nil)
     return nil;
-  
+
   if ([p hasSuffix:@"/"])
     return p;
 
   if (![[self absoluteString] hasSuffix:@"/"])
     return p;
-  
+
   /* so we are running into the bug ... */
   return [p stringByAppendingString:@"/"];
 #else
@@ -54,20 +54,20 @@ static BOOL debugURLProcessing = NO;
 
 - (NSString *)stringByAddingFragmentAndQueryToPath:(NSString *)_path {
   NSString *lFrag, *lQuery;
-  
+
   if ([self isFileURL])
     return _path;
-  
+
   lFrag   = [self fragment];
   lQuery  = [self query];
-  
+
   if ((lFrag != nil) || (lQuery != nil)) {
     NSMutableString *ms;
-    
+
     ms = [NSMutableString stringWithCapacity:([_path length] + 32)];
-    
+
     [ms appendString:_path];
-    
+
     if (lFrag) {
       [ms appendString:@"#"];
       [ms appendString:lFrag];
@@ -88,26 +88,26 @@ static BOOL debugURLProcessing = NO;
       self: http://localhost:20000/dbd.woa/so/localhost/Databases/A
       base: http://localhost:20000/dbd.woa/so/localhost/
          => Databases/A
-    
+
     Note: on Panther Foundation the -path misses the trailing slash!
   */
   NSString *relPath;
-  
+
   if (_base == self || _base == nil) {
     relPath = [self pathWithCorrectTrailingSlash];
     relPath = [relPath urlPathRelativeToSelf];
     relPath = [self stringByAddingFragmentAndQueryToPath:relPath];
     if (debugURLProcessing) {
-      NSLog(@"%s: no base or base is self => '%@'", 
+      NSLog(@"%s: no base or base is self => '%@'",
 	    __PRETTY_FUNCTION__, relPath);
     }
     return relPath;
   }
-  
+
   /* check whether we are already marked relative to _base .. */
   if ([self baseURL] == _base) {
     NSString *p;
-    
+
     p = [self relativePath];
 #if COCOA_Foundation_LIBRARY || NeXT_Foundation_LIBRARY
     /* see -pathWithCorrectTrailingSlash for bug description ... */
@@ -118,34 +118,34 @@ static BOOL debugURLProcessing = NO;
 #endif
     p = [self stringByAddingFragmentAndQueryToPath:p];
     if (debugURLProcessing) {
-      NSLog(@"%s: url base and _base match => '%@'", 
+      NSLog(@"%s: url base and _base match => '%@'",
 	    __PRETTY_FUNCTION__, p);
     }
     return p;
   }
-  
+
   /* check whether we are in the same path namespace ... */
   if (![self isInSameNamespaceWithURL:_base]) {
     /* need to return full URL */
     relPath = [self absoluteString];
     if (debugURLProcessing) {
-      NSLog(@"%s: url is in different namespace from base => '%@'", 
+      NSLog(@"%s: url is in different namespace from base => '%@'",
 	    __PRETTY_FUNCTION__, relPath);
     }
     return relPath;
   }
-  
-  relPath = [[self pathWithCorrectTrailingSlash] 
+
+  relPath = [[self pathWithCorrectTrailingSlash]
                    urlPathRelativeToPath:[_base pathWithCorrectTrailingSlash]];
   if (debugURLProcessing) {
     NSLog(@"%s: path '%@', base-path '%@' => rel '%@'", __PRETTY_FUNCTION__,
 	  [self path], [_base path], relPath);
   }
   relPath = [self stringByAddingFragmentAndQueryToPath:relPath];
-  
+
   if (debugURLProcessing) {
-    NSLog(@"%s: same namespace, but no direct relative (%@, base %@) => '%@'", 
-	  __PRETTY_FUNCTION__, 
+    NSLog(@"%s: same namespace, but no direct relative (%@, base %@) => '%@'",
+	  __PRETTY_FUNCTION__,
 	  [self absoluteString], [_base absoluteString], relPath);
   }
   return relPath;
@@ -163,17 +163,17 @@ static BOOL isEqual(id o1, id o2) {
   if ([self isFileURL] && [_url isFileURL]) return YES;
   if ([self baseURL] == _url) return YES;
   if ([_url baseURL] == self) return YES;
-  
+
   if (![[self scheme] isEqualToString:[_url scheme]])
     return NO;
-  
+
   if (!isEqual([self host], [_url host]))
     return NO;
   if (!isEqual([self port], [_url port]))
     return NO;
   if (!isEqual([self user], [_url user]))
     return NO;
-  
+
   return YES;
 }
 
@@ -185,7 +185,7 @@ static BOOL isEqual(id o1, id o2) {
   /*
     eg:                "/a/b/c.html"
     should resolve to: "c.html"
-    
+
     Directories are a bit more difficult, eg:
       "/a/b/c/"
     is resolved to
@@ -198,30 +198,30 @@ static BOOL isEqual(id o1, id o2) {
     /SOGo/so/X/Mail/Y/INBOX/withsubdirs/
     ..//SOGo/so/X/Mail/Y/INBOX/withsubdirs//
   */
-  
+
   p  = self;
   lp = [p lastPathComponent];
   if (![p hasSuffix:@"/"])
     return lp;
-  
+
   return [[@"../" stringByAppendingString:lp] stringByAppendingString:@"/"];
 }
 
 - (NSString *)urlPathRelativeToRoot {
   NSString *p;
-  
+
   p = self;
-  
+
   if ([p isEqualToString:@"/"])
     /* don't know better ... what is root-relative-to-root ? */
     return @"/";
-  
+
   if ([p length] == 0) {
     NSLog(@"%s: invalid path (length 0), using /: %@",
           __PRETTY_FUNCTION__, self);
     return @"/";
   }
-  
+
   /* this is the same like the absolute path, only without a leading "/" .. */
   return [p characterAtIndex:0] == '/' ? [p substringFromIndex:1] : p;
 }
@@ -241,17 +241,17 @@ static NSString *calcRelativePathOfChildURL(NSString *self, NSString *_base) {
           b: "/a/b/c"
           s: "/a/b/ccc/d"
           >: "ccc/d"
-        
+
       b=s is already catched above and s is guaranteed to be
       longer than b.
   */
   unsigned blen;
   NSString *result;
-    
+
   if (debugURLProcessing)
       NSLog(@"%s:   has base as prefix ...", __PRETTY_FUNCTION__);
   blen = [_base length];
-    
+
   if ([_base characterAtIndex:(blen - 1)] == '/') {
       /* last char of 'b' is '/' => case b) */
       result = [self substringFromIndex:blen];
@@ -262,7 +262,7 @@ static NSString *calcRelativePathOfChildURL(NSString *self, NSString *_base) {
         both are handled in the same way (search last / ...)
       */
       NSRange  r;
-        
+
       r = [_base rangeOfString:@"/" options:NSBackwardsSearch];
       if (r.length == 0) {
         NSLog(@"%s: invalid base, found no '/': '%@' !",
@@ -283,37 +283,37 @@ static NSString *calcRelativePathOfChildURL(NSString *self, NSString *_base) {
   NSString *s;
   unsigned len;
   NSRange  r;
-  
+
   if (_other == self)
     return self;
-  
+
   s   = [self commonPrefixWithString:_other options:0];
   len = [s length];
   if (len == 0)
     return s;
   if ([s characterAtIndex:(len - 1)] == '/')
     return s;
-  
+
   r = [s rangeOfString:@"/" options:NSBackwardsSearch];
   if (r.length == 0) /* hm, can't happen? */
     return nil;
-  
+
   return [s substringToIndex:(r.location + r.length)];;
 }
 
-static 
+static
 NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
   unsigned numSlashes;
   NSString *result;
   NSString *prefix;
   NSString *suffix;
   unsigned plen;
-  
+
   prefix     = [self commonDirPathPrefixWithString:_base];
   plen       = [prefix length];
   suffix     = [self substringFromIndex:plen];
   numSlashes = 0;
-    
+
   if (debugURLProcessing) {
     NSLog(@"%s:   does not have base as prefix, common '%@'\n"
 	  @"  self='%@'\n"
@@ -321,35 +321,35 @@ NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
 	  @"  suffix='%@'",
 	  __PRETTY_FUNCTION__, prefix, self, _base, suffix);
   }
-    
+
   if (plen == 0) {
       NSLog(@"%s: invalid strings, no common prefix ...: '%@' and '%@' !",
               __PRETTY_FUNCTION__, self, _base);
       return self;
   }
-    
+
   if (plen == 1) {
       /*
         common prefix is root. That is, nothing in common:
           b: "/a/b"
           s: "/l"
           >: "../l"
-          
+
           b: "/a/b/"
           s: "/l"
           >: "../../l"
 	(number of slashes without root * "..", then the trailer?)
       */
       unsigned i, len;
-      
+
       len = [_base length];
-      
+
       if ([prefix characterAtIndex:0] != '/') {
         NSLog(@"%s: invalid strings, common prefix '%@' is not '/': "
               @"'%@' and '%@' !",
               __PRETTY_FUNCTION__, self, _base, prefix);
       }
-      
+
       for (i = 1 /* skip root */; i < len; i++) {
 	if ([_base characterAtIndex:i] == '/')
 	  numSlashes++;
@@ -363,10 +363,10 @@ NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
       */
       NSString *basesuffix;
       unsigned i, len;
-      
+
       basesuffix = [_base substringFromIndex:plen];
       len        = [basesuffix length];
-      
+
       for (i = 0; i < len; i++) {
 	if ([basesuffix characterAtIndex:i] == '/')
 	  numSlashes++;
@@ -375,7 +375,7 @@ NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
 
   if (debugURLProcessing)
     NSLog(@"%s:   slashes: %d", __PRETTY_FUNCTION__, numSlashes);
-    
+
   /* optimization for some depths */
   switch (numSlashes) {
     case 0: /* no slashes in base: b:/a, s:/images/a => images/a */
@@ -391,7 +391,7 @@ NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
     default: {
       NSMutableString *ms;
       unsigned i;
-      
+
       ms = [NSMutableString stringWithCapacity:(numSlashes * 3)];
       for (i = 0; i < numSlashes; i++)
 	[ms appendString:@"../"];
@@ -411,25 +411,53 @@ NSString *calcRelativePathOfNonChildURL(NSString *self, NSString *_base) {
     never return an absolute path (it only does in error conditions).
   */
   // TODO: the implementation can probably be optimized a _LOT_
-  
+
   if (_base == nil || [_base length] == 0) {
     NSLog(@"%s: invalid base (nil or length 0), using absolute path '%@' ...",
           __PRETTY_FUNCTION__, self);
     return self;
   }
-  
+
   if ([_base isEqualToString:@"/"])
     return [self urlPathRelativeToRoot];
   if ([_base isEqualToString:self])
     return [self urlPathRelativeToSelf];
-  
+
   if (debugURLProcessing)
     NSLog(@"%s: %@ relative to %@ ...", __PRETTY_FUNCTION__, self, _base);
-  
+
   if ([self hasPrefix:_base])
     return calcRelativePathOfChildURL(self, _base);
-  
+
   return calcRelativePathOfNonChildURL(self, _base);
 }
 
 @end /* NSString(URLPathProcessing) */
+
+
+@implementation NSURL(QueryComponents)
+
+- (NSDictionary *) queryComponents
+{
+  NSString *query = [self query];
+  NSArray *pairs = [query componentsSeparatedByString: @"&"];
+  NSMutableDictionary *components = [NSMutableDictionary dictionary];
+  NSEnumerator *e = [pairs objectEnumerator];
+  NSString *pair;
+  while ((pair = [e nextObject]) != nil) {
+    NSString *key, *value;
+    NSArray *keyVal = [pair componentsSeparatedByString: @"="];
+    if ([keyVal count] != 2) {
+      continue;
+    }
+    key = [[keyVal objectAtIndex:0] stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+    if ([key length] == 0) {
+      continue;
+    }
+    value = [[keyVal objectAtIndex:1] stringByReplacingPercentEscapesUsingEncoding: NSUTF8StringEncoding];
+    [components setObject:value forKey:key];
+  }
+  return components;
+}
+
+@end /* NSURL(QueryComponents)*/

--- a/sope-core/NGExtensions/NGExtensions/NSURL+misc.h
+++ b/sope-core/NGExtensions/NGExtensions/NSURL+misc.h
@@ -26,6 +26,8 @@
 #import <Foundation/NSURL.h>
 #import <Foundation/NSString.h>
 
+@class NSDictionary;
+
 @interface NSURL(misc)
 
 /*
@@ -54,7 +56,7 @@
 /*
   eg:                "/a/b/c.html"
   should resolve to: "c.html"
-    
+
   Directories are a bit more difficult, eg:
     "/a/b/c/"
   is resolved to
@@ -70,6 +72,12 @@
   never return an absolute path (it only does in error conditions).
 */
 - (NSString *)urlPathRelativeToPath:(NSString *)_base;
+
+@end
+
+@interface NSURL (QueryComponents)
+
+- (NSDictionary *) queryComponents;
 
 @end
 

--- a/sope-core/NGStreams/NGLocalSocketAddress.m
+++ b/sope-core/NGStreams/NGLocalSocketAddress.m
@@ -67,15 +67,15 @@ static NSString *socketDirectoryPath = @"/tmp";
 - (id)initWithPath:(NSString *)_path {
   if ((self = [super init])) {
     self->address = calloc(1, sizeof(struct sockaddr_un));
-    
+
     memset(self->address, 0, sizeof(struct sockaddr_un));
-    
+
 #if defined(__WIN32__) && !defined(__CYGWIN32__)
     self->path = [_path copyWithZone:[self zone]];
 #else
     if ([_path cStringLength] >=
         sizeof(((struct sockaddr_un *)self->address)->sun_path)) {
-      
+
       NSLog(@"LocalDomain name too long: maxlen=%i, len=%i, path=%@",
             (int)sizeof(((struct sockaddr_un *)self->address)->sun_path),
             (int)[_path cStringLength],
@@ -85,7 +85,7 @@ static NSString *socketDirectoryPath = @"/tmp";
       [self release];
       return nil;
     }
-    
+
     ((struct sockaddr_un *)self->address)->sun_family =
       [[self domain] socketDomain];
 
@@ -99,7 +99,7 @@ static NSString *socketDirectoryPath = @"/tmp";
 - (id)init {
   int      addressCounter = 0;
   NSString *newPath;
-  
+
   newPath = [NSString stringWithFormat:@"_ngsocket_%d_%p_%03d",
                         (int)getpid(), [NSThread currentThread], addressCounter];
   newPath = [socketDirectoryPath stringByAppendingPathComponent:newPath];
@@ -118,7 +118,7 @@ static NSString *socketDirectoryPath = @"/tmp";
   path = (_length < 3)
     ? (id)@""
     : [[NSString alloc] initWithCString:nun->sun_path];
-  
+
   self = [self initWithPath:path];
   [path release]; path = nil;
   return self;
@@ -137,7 +137,7 @@ static NSString *socketDirectoryPath = @"/tmp";
   sp = ((struct sockaddr_un *)self->address)->sun_path;
   if (strlen(sp) == 0)
     return @"";
-  
+
   return [NSString stringWithCString:sp];
 }
 
@@ -145,11 +145,11 @@ static NSString *socketDirectoryPath = @"/tmp";
 
 - (void)deletePath {
   const char *sp;
-  
+
   sp = ((struct sockaddr_un *)self->address)->sun_path;
   if (strlen(sp) == 0)
     return;
-  
+
   unlink(sp);
 }
 
@@ -163,6 +163,14 @@ static NSString *socketDirectoryPath = @"/tmp";
 }
 - (id)domain {
   return [NGLocalSocketDomain domain];
+}
+
+- (BOOL) isLocalhost {
+  return YES;
+}
+
+- (NSString *) hostName {
+  return @"localhost";
 }
 
 /* test for accessibility */
@@ -226,7 +234,7 @@ static NSString *socketDirectoryPath = @"/tmp";
 
 - (NSString *)description {
   NSString *p = [self path];
-  
+
   if ([p length] == 0)
     p = @"[no path]";
 

--- a/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
+++ b/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
@@ -38,12 +38,19 @@
   void *ssl;   /* real type: SSL */
 #endif
   NSString *hostName;
+  BOOL validatePeer;
 }
 + (id) socketConnectedToAddress: (id<NGSocketAddress>) _address
                   onHostName: (NSString *) hostName;
 
 - (id)initWithDomain:(id<NGSocketDomain>)_domain
       onHostName: (NSString *)_hostName;
+
+/**
+ * enable/disable peer certificate validation. must be called before
+ * the handshake is performed. Default is enabled.
+ */
+- (void) validatePeerCertificate:(BOOL)_validate;
 
 - (BOOL) startTLS;
 @end

--- a/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
+++ b/sope-core/NGStreams/NGStreams/NGActiveSSLSocket.h
@@ -24,8 +24,15 @@
 #define __NGNet_NGActiveSSLSocket_H__
 
 #import <NGStreams/NGSocketProtocols.h>
+#import <NGStreams/NGInternetSocketAddress.h>
 #include <NGStreams/NGActiveSocket.h>
 #include "../config.h"
+
+enum {
+  TLSVerifyDefault = 0,
+  TLSVerifyNone = 1,
+  TLSVerifyAllowInsecureLocalhost = 2
+};
 
 @interface NGActiveSSLSocket : NGActiveSocket
 {
@@ -40,17 +47,17 @@
   NSString *hostName;
   BOOL validatePeer;
 }
+
 + (id) socketConnectedToAddress: (id<NGSocketAddress>) _address
-                  onHostName: (NSString *) hostName;
+                 withVerifyMode: (int) mode;
 
-- (id)initWithDomain:(id<NGSocketDomain>)_domain
-      onHostName: (NSString *)_hostName;
-
+- (id)initWithConnectedActiveSocket: (NGActiveSocket *) _socket
+                     withVerifyMode: (int) mode;
 /**
  * enable/disable peer certificate validation. must be called before
  * the handshake is performed. Default is enabled.
  */
-- (void) validatePeerCertificate:(BOOL)_validate;
+- (void) validatePeerCertificate: (BOOL) validate;
 
 - (BOOL) startTLS;
 @end

--- a/sope-core/NGStreams/NGStreams/NGInternetSocketAddress.h
+++ b/sope-core/NGStreams/NGStreams/NGInternetSocketAddress.h
@@ -27,7 +27,7 @@
 
 /*
   Represents an Internet socket address (AF_INET).
-  
+
   Socket addresses are immutable. -copy therefore returns a retained self.
 
   The host arguments are id because they are allowed to be either NSString
@@ -66,7 +66,6 @@
 
 /* accessors */
 
-- (NSString *)hostName;
 - (NSString *)address;
 - (int)port;
 

--- a/sope-core/NGStreams/NGStreams/NGSocketProtocols.h
+++ b/sope-core/NGStreams/NGStreams/NGSocketProtocols.h
@@ -34,6 +34,8 @@
 - (void *)internalAddressRepresentation;
 - (int)addressRepresentationSize;
 - (id)domain; // (a NGSocketDomain)
+- (BOOL) isLocalhost;
+- (NSString *)hostName;
 
 // needed by socket address factory:
 - (id)initWithDomain:(id)_domain

--- a/sope-mime/NGImap4/NGImap4Client.h
+++ b/sope-mime/NGImap4/NGImap4Client.h
@@ -29,14 +29,14 @@
 
 /*
   NGImap4Client
-  
+
   An IMAP4 client object. This object is a thin wrapper around the TCP/IP
   socket (id<NGActiveSocket> object) connecting to the IMAP4 server.
-  
+
   While it is pretty near to the IMAP4 raw protocol, it already does some
   normalization of responses. We might want to have something which is even
   lower level in the future.
-  
+
   Responses are send to all registered response receivers.
   TODO: explain notification system.
 */
@@ -61,7 +61,7 @@ typedef enum {
   id<NGSocketAddress>       address;
   NGImap4ResponseParser     *parser;
   NGImap4ResponseNormalizer *normer;
-  NSMutableArray            *responseReceiver;  
+  NSMutableArray            *responseReceiver;
 
   BOOL	   loggedIn;
   BOOL     useAuthenticate;
@@ -81,6 +81,7 @@ typedef enum {
   BOOL useSSL;
   BOOL useTLS;
   BOOL useUTF8;
+  int tlsVerifyMode;
 
   NGImap4Context *context; /* not retained, used to store exceptions */
   EOGlobalID *serverGID;
@@ -126,7 +127,7 @@ typedef enum {
                      mechanism:(NSString *)_mech;
 - (NSDictionary *)logout;
 - (NSDictionary *)noop;
-  
+
 - (NSDictionary *)capability;
 - (NSDictionary *)enable:(NSArray *)_extensions;
 
@@ -145,7 +146,7 @@ typedef enum {
 - (NSDictionary *)subscribe:(NSString *)_name;
 - (NSDictionary *)unsubscribe:(NSString *)_name;
 - (NSDictionary *)expunge;
-  
+
 - (NSDictionary *)sort:(id)_sortOrderings qualifier:(EOQualifier *)_qual
   encoding:(NSString *)_encoding;
 - (NSDictionary *)fetchUids:(NSArray *)_uids parts:(NSArray *)_parts;

--- a/sope-mime/NGImap4/NGImap4Client.m
+++ b/sope-mime/NGImap4/NGImap4Client.m
@@ -21,7 +21,6 @@
 */
 
 #include <unistd.h>
-#include <fcntl.h>
 
 #include "NGImap4Client.h"
 #include "NGImap4Context.h"
@@ -303,7 +302,7 @@ static NSMutableDictionary *namespaces;
   NS_DURING {
       if (sslSocket) {
         sock = [NGActiveSSLSocket socketConnectedToAddress:self->address
-          onHostName: [(NGInternetSocketAddress *)self->address hostName]];
+                                            withVerifyMode: TLSVerifyDefault];
       } else {
         sock = [NGActiveSocket socketConnectedToAddress:self->address];
       }
@@ -342,17 +341,10 @@ static NSMutableDictionary *namespaces;
 
 	if ([[d valueForKey:@"result"] boolValue])
 	  {
-	    int oldopts;
 	    id o;
 
-	    o = [[NGActiveSSLSocket alloc] initWithDomain: [self->address domain]
-          onHostName: [(NGInternetSocketAddress *)self->address hostName]];
-	    [o setFileDescriptor: [(NGSocket*)self->socket fileDescriptor]];
-
-	    // We remove the NON-BLOCKING I/O flag on the file descriptor, otherwise
-	    // SOPE will break on SSL-sockets.
-	    oldopts = fcntl([(NGSocket*)self->socket fileDescriptor], F_GETFL, 0);
-	    fcntl([(NGSocket*)self->socket fileDescriptor], F_SETFL, oldopts & !O_NONBLOCK);
+	    o = [[NGActiveSSLSocket alloc] initWithConnectedActiveSocket: (NGActiveSocket *)self->socket
+            withVerifyMode: TLSVerifyDefault];
 
 	    if ([o startTLS])
 	      {

--- a/sope-mime/NGImap4/NGSieveClient.h
+++ b/sope-mime/NGImap4/NGSieveClient.h
@@ -30,7 +30,7 @@
 
 /*
   NGSieveClient
-  
+
   This implements a client for server stored Sieve scripts as supported by
   the Cyrus IMAP server.
 */
@@ -60,13 +60,14 @@ typedef enum {
 
   NSString *authname;
   NSString *login;
-  NSString *password; 
+  NSString *password;
 
   NSString *serverType;
   NSArray  *capabilities;
-  
+
   BOOL debug;
   BOOL useTLS;
+  int tlsVerifyMode;
 }
 
 + (id)clientWithURL:(id)_url;

--- a/sope-mime/NGImap4/NGSieveClient.m
+++ b/sope-mime/NGImap4/NGSieveClient.m
@@ -23,7 +23,6 @@
 */
 
 #include <unistd.h>
-#include <fcntl.h>
 
 #include "NGSieveClient.h"
 #include "NGImap4Support.h"
@@ -58,11 +57,11 @@
 
 /*
   An implementation of an Imap4 client
-  
+
   A folder name always looks like an absolute filename (/inbox/blah)
-  
+
   NOTE: Sieve is just the filtering language ...
-  
+
   This should be ACAP?
     http://asg.web.cmu.edu/rfc/rfc2244.html
 
@@ -89,12 +88,12 @@ static BOOL     debugImap4         = NO;
   NSUserDefaults *ud;
   if (didInit) return;
   didInit = YES;
-  
+
   ud = [NSUserDefaults standardUserDefaults];
   LOG_PASSWORD       = [ud boolForKey:@"SieveLogPassword"];
   ProfileImapEnabled = [ud boolForKey:@"ProfileImapEnabled"];
   debugImap4         = [ud boolForKey:@"ImapDebugEnabled"];
-  
+
   YesNumber = [[NSNumber numberWithBool:YES] retain];
   NoNumber  = [[NSNumber numberWithBool:NO] retain];
 }
@@ -105,7 +104,7 @@ static BOOL     debugImap4         = NO;
 
 + (id)clientWithAddress:(id<NGSocketAddress>)_address {
   NGSieveClient *client;
-  
+
   client = [self alloc];
   return [[client initWithAddress:_address] autorelease];
 }
@@ -117,11 +116,11 @@ static BOOL     debugImap4         = NO;
 - (id)initWithNSURL:(NSURL *)_url {
   NGInternetSocketAddress *a;
   int port;
-  
+
   if ((port = [[_url port] intValue]) == 0)
     port = defaultSievePort;
 
-  a = [NGInternetSocketAddress addressWithPort:port 
+  a = [NGInternetSocketAddress addressWithPort:port
 			       onHost:[_url host]];
   if ((self = [self initWithAddress:a])) {
     self->login    = [[_url user]     copy];
@@ -132,7 +131,7 @@ static BOOL     debugImap4         = NO;
       else
 	self->useTLS = NO;
   }
-  
+
   serverType = nil;
   capabilities = nil;
 
@@ -143,16 +142,16 @@ static BOOL     debugImap4         = NO;
     [self release];
     return nil;
   }
-  
+
   if (![_url isKindOfClass:[NSURL class]])
     _url = [NSURL URLWithString:[_url stringValue]];
-  
+
   return [self initWithNSURL:_url];
 }
 
 - (id)initWithHost:(id)_host {
   NGInternetSocketAddress *a;
-  
+
   a = [NGInternetSocketAddress addressWithPort:defaultSievePort onHost:_host];
   return [self initWithAddress:a];
 }
@@ -257,9 +256,9 @@ static BOOL     debugImap4         = NO;
     gettimeofday(&tv, NULL);
     ti =  (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0);
   }
-  
+
   [self resetStreams];
-  
+
   [self->previous_socket release];
   self->previous_socket = nil;
   self->socket =
@@ -279,7 +278,7 @@ static BOOL     debugImap4         = NO;
     gettimeofday(&tv, NULL);
     ti = (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0) - ti;
     fprintf(stderr, "[%s] <openConnection> : time needed: %4.4fs\n",
-           __PRETTY_FUNCTION__, ti < 0.0 ? -1.0 : ti);    
+           __PRETTY_FUNCTION__, ti < 0.0 ? -1.0 : ti);
   }
 
   res = [self normalizeOpenConnectionResponse:
@@ -287,33 +286,26 @@ static BOOL     debugImap4         = NO;
 
   ASSIGN(serverType, [res objectForKey: @"server"]);
   ASSIGN(capabilities, [[res objectForKey:@"capabilities"] componentsSeparatedByString: @" "]);
-         
+
 
   // If we're using TLS, we start it here
   if (self->useTLS)
     {
       NSDictionary *d;
-      
+
       d = [self normalizeResponse:[self processCommand: @"STARTTLS"]];
 
       if ([[d valueForKey:@"result"] boolValue])
 	{
-	  int oldopts;
 	  id o;
 
-	  o = [[NGActiveSSLSocket alloc] initWithDomain: [self->address domain]
-	                                     onHostName: [(NGInternetSocketAddress *)self->address hostName]];
-	  [o setFileDescriptor: [(NGSocket*)self->socket fileDescriptor]];
-	  
-	  // We remove the NON-BLOCKING I/O flag on the file descriptor, otherwise
-	  // SOPE will break on SSL-sockets.
-	  oldopts = fcntl([(NGSocket*)self->socket fileDescriptor], F_GETFL, 0);
-	  fcntl([(NGSocket*)self->socket fileDescriptor], F_SETFL, oldopts & !O_NONBLOCK);
-	    
+	  o = [[NGActiveSSLSocket alloc] initWithConnectedActiveSocket: (NGActiveSocket *)self->socket
+	                                     withVerifyMode: TLSVerifyDefault];
+
 	  if ([o startTLS])
 	    {
 	      //NGBufferedStream *buffer;
-	      
+
 	      // We keep a reference to our previous instance of NGActiveSocket as
 	      // it's still being used. NGActiveSSLSocket's read/write methods are
 	      // being used but the rest is coming of directly from NGActiveSocket
@@ -321,12 +313,12 @@ static BOOL     debugImap4         = NO;
 	      self->socket = o;
 	      //[self->text release];
 	      [self->parser release];
-	      
+
 	      self->io = [(NGBufferedStream *)[NGBufferedStream alloc] initWithSource: self->socket];
 	      //self->text = [(NGCTextStream *)[NGCTextStream alloc] initWithSource: buffer];
 	      //[buffer release];
 	      //buffer = nil;
-	      
+
 	      self->parser = [[NGImap4ResponseParser alloc] initWithStream: self->socket];
 	      [self logWithFormat:@"TLS started successfully."];
 
@@ -362,17 +354,17 @@ static BOOL     debugImap4         = NO;
   // TODO: why does that return an object?
   if (self->socket == nil)
     return [NSNumber numberWithBool:NO];
-  
+
   return [NSNumber numberWithBool:[(NGActiveSocket *)self->socket isAlive]];
 }
 
 - (void)closeConnection {
   [self->socket close];
   [self->socket release]; self->socket = nil;
-  
+
   [self->previous_socket close];
   [self->previous_socket release]; self->previous_socket = nil;
-   
+
   [self->parser release]; self->parser = nil;
 }
 
@@ -382,14 +374,14 @@ static BOOL     debugImap4         = NO;
 
 - (NSDictionary *)login:(NSString *)_login authname:(NSString *)_authname password:(NSString *)_passwd {
   /* login with plaintext password authenticating */
-  
+
   if ((_login == nil) || (_passwd == nil))
     return nil;
-  
+
   [self->authname release]; self->authname = nil;
   [self->login    release]; self->login    = nil;
   [self->password release]; self->password = nil;
-  
+
   self->authname = [_authname copy];
   self->login    = [_login  copy];
   self->password = [_passwd copy];
@@ -397,7 +389,7 @@ static BOOL     debugImap4         = NO;
 }
 
 - (void)reconnect {
-  [self closeConnection];  
+  [self closeConnection];
   [self openConnection];
   [self login];
 }
@@ -407,42 +399,42 @@ static BOOL     debugImap4         = NO;
   NSData    *auth;
   char      *buf;
   int       bufLen, logLen, authLen;
-  
+
   if (![self->socket isConnected]) {
     NSDictionary *con;
-    
+
     if ((con = [self openConnection]) == nil)
       return nil;
     if (![[con objectForKey:@"result"] boolValue])
       return con;
   }
-  
+
   authLen = [self->authname lengthOfBytesUsingEncoding: NSUTF8StringEncoding];
   logLen = [self->login lengthOfBytesUsingEncoding: NSUTF8StringEncoding];
   bufLen = (logLen+authLen) + [self->password lengthOfBytesUsingEncoding: NSUTF8StringEncoding] +2;
-  
+
   buf = calloc(bufLen + 2, sizeof(char));
-  
+
   /*
     Format:
       authenticate-id
       authorize-id
       password
   */
-  sprintf(buf, "%s %s %s", 
+  sprintf(buf, "%s %s %s",
           [self->login cStringUsingEncoding:NSUTF8StringEncoding],
           [self->authname cStringUsingEncoding:NSUTF8StringEncoding],
           [self->password cStringUsingEncoding:NSUTF8StringEncoding]);
-  
+
   buf[logLen] = '\0';
   buf[logLen+authLen + 1] = '\0';
-  
+
   auth = [NSData dataWithBytesNoCopy:buf length:bufLen];
   auth = [auth dataByEncodingBase64WithLineLength:4096 /* 'unlimited' */];
-  
+
   if (LOG_PASSWORD) {
     NSString *s;
-    
+
     s = [NSString stringWithFormat:@"AUTHENTICATE \"PLAIN\" {%d+}\r\n%s",
                   (int)[auth length], [auth bytes]];
     map = [self processCommand:s
@@ -451,7 +443,7 @@ static BOOL     debugImap4         = NO;
   }
   else {
     NSString *s;
-    
+
     s = [NSString stringWithFormat:@"AUTHENTICATE \"PLAIN\" {%d+}\r\n%s",
                   (int)[auth length], [auth bytes]];
     map = [self processCommand:s
@@ -463,7 +455,7 @@ static BOOL     debugImap4         = NO;
     [self logWithFormat:@"ERROR: got no result from command."];
     return nil;
   }
-  
+
   return [self normalizeResponse:map];
 }
 
@@ -480,7 +472,7 @@ static BOOL     debugImap4         = NO;
 - (NSString *)getScript:(NSString *)_scriptName {
   NSException *ex;
   NSString *script, *s;
-  
+
   s = [@"GETSCRIPT \"" stringByAppendingString:_scriptName];
   s = [s stringByAppendingString:@"\""];
   ex = [self sendCommand:s logText:s attempts:3];
@@ -489,24 +481,24 @@ static BOOL     debugImap4         = NO;
     [self setLastException:ex];
     return nil;
   }
-  
+
   /* read script string */
-  
+
   if ((script = [[self readString] autorelease]) == nil)
     return nil;
-  
+
   if ([script hasPrefix:@"O "] || [script hasPrefix:@"NO "]) {
     // TODO: not exactly correct, script could begin with this signature
     // Note: readString read 'NO ...', but the first char is consumed
-    
+
     [self logWithFormat:@"ERROR: status line reports: '%@'", script];
     return nil;
   }
-  
+
   NSLog(@"str: %@", script);
-  
+
   /* read response code */
-  
+
   if ((s = [self readStringToCRLF]) == nil) {
     [self logWithFormat:@"ERROR: could not parse status line."];
     return nil;
@@ -518,14 +510,14 @@ static BOOL     debugImap4         = NO;
       return nil;
     }
   }
-  
+
   if (![s hasPrefix:@"OK"]) {
     [self logWithFormat:@"ERROR: status line reports: '%@'", s];
     [s release];
     return nil;
   }
   [s release];
-  
+
   return script;
 }
 
@@ -537,7 +529,7 @@ static BOOL     debugImap4         = NO;
   // TODO: script should be send in UTF-8!
   NGHashMap *map;
   NSString  *s;
-  
+
   if (![self isValidScriptName:_name]) {
     [self logWithFormat:@"%s: missing script-name", __PRETTY_FUNCTION__];
     return nil;
@@ -546,7 +538,7 @@ static BOOL     debugImap4         = NO;
     [self logWithFormat:@"%s: missing script", __PRETTY_FUNCTION__];
     return nil;
   }
-  
+
   s = @"PUTSCRIPT \"";
   s = [s stringByAppendingString:_name];
   s = [s stringByAppendingString:@"\" "];
@@ -559,7 +551,7 @@ static BOOL     debugImap4         = NO;
 
 - (NSDictionary *)setActiveScript:(NSString *)_name {
   NGHashMap *map;
-  
+
   if (!_name) {
     NSLog(@"%s: missing script-name", __PRETTY_FUNCTION__);
     return nil;
@@ -577,7 +569,7 @@ static BOOL     debugImap4         = NO;
     NSLog(@"%s: missing script-name", __PRETTY_FUNCTION__);
     return nil;
   }
-  
+
   s = [NSString stringWithFormat:@"DELETESCRIPT \"%@\"", _name];
   map = [self processCommand:s];
   return [self normalizeResponse:map];
@@ -587,26 +579,26 @@ static BOOL     debugImap4         = NO;
   NSMutableDictionary *md;
   NSException *ex;
   NSString *line;
-  
+
   ex = [self sendCommand:@"LISTSCRIPTS" logText:@"LISTSCRIPTS" attempts:3];
   if (ex != nil) {
     [self logWithFormat:@"ERROR: could not list scripts: %@", ex];
     [self setLastException:ex];
     return nil;
   }
-  
+
   /* read response */
-  
+
   md = [NSMutableDictionary dictionaryWithCapacity:16];
   while ((line = [self readStringToCRLF]) != nil) {
     if ([line hasPrefix:@"OK"])
       break;
-    
+
     if ([line hasPrefix:@"NO"]) {
       md = nil;
       break;
     }
-    
+
     if ([line hasPrefix:@"{"]) {
       [self logWithFormat:@"unsupported list response line: '%@'", line];
     }
@@ -614,31 +606,31 @@ static BOOL     debugImap4         = NO;
       NSString *s;
       NSRange  r;
       BOOL     isActive;
-      
+
       s = [line substringFromIndex:1];
       r = [s rangeOfString:@"\""];
-      
+
       if (r.length == 0) {
 	[self logWithFormat:@"missing closing quote in line: '%@'", line];
 	[line release]; line = nil;
 	continue;
       }
-      
+
       s = [s substringToIndex:r.location];
       isActive = [line rangeOfString:@"ACTIVE"].length == 0 ? NO : YES;
-      
+
       [md setObject:[NSNumber numberWithBool: isActive] forKey:s];
     }
     else {
-      [self logWithFormat:@"unexpected list response line (%d): '%@'", 
+      [self logWithFormat:@"unexpected list response line (%d): '%@'",
 	    [line length], line];
     }
-    
+
     [line release]; line = nil;
   }
-  
+
   [line release]; line = nil;
-  
+
   return md;
 }
 
@@ -654,7 +646,7 @@ static BOOL     debugImap4         = NO;
   */
   id keys[3], values[3];
   NSParameterAssert(_map != nil);
-  
+
   keys[0] = @"RawResponse"; values[0] = _map;
   keys[1] = @"result";
   values[1] = [[_map objectForKey:@"ok"] boolValue] ? YesNumber : NoNumber;
@@ -666,9 +658,9 @@ static BOOL     debugImap4         = NO;
   /* filter for open connection */
   NSMutableDictionary *result;
   NSString *tmp;
-  
+
   result = [self normalizeResponse:_map];
-  
+
   if (![[[_map objectEnumeratorForKey:@"ok"] nextObject] boolValue])
     return result;
 
@@ -688,10 +680,10 @@ static BOOL     debugImap4         = NO;
     [_exception raise];
     return NO;
   }
-  
+
   if ([_exception isKindOfClass:[NGIOException class]]) {
     [self logWithFormat:
-            @"WARNING: got exception try to restore connection: %@", 
+            @"WARNING: got exception try to restore connection: %@",
             _exception];
     return YES;
   }
@@ -701,14 +693,14 @@ static BOOL     debugImap4         = NO;
             _exception];
     return YES;
   }
-  
+
   [_exception raise];
   return NO;
 }
 
 - (void)waitPriorReconnectWithRepetitionCount:(int)_cnt {
   unsigned timeout;
-  
+
   timeout = _cnt * 2;
   [self logWithFormat:@"reconnect to %@, sleeping %d seconds ...",
           self->address, timeout];
@@ -733,7 +725,7 @@ static BOOL     debugImap4         = NO;
   int       repeatCnt     = 0;
   struct timeval tv;
   double         ti = 0.0;
-  
+
   if (ProfileImapEnabled) {
     gettimeofday(&tv, NULL);
     ti =  (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0);
@@ -743,18 +735,18 @@ static BOOL     debugImap4         = NO;
     if (repeatCommand) {
       if (repeatCnt > 1)
         [self waitPriorReconnectWithRepetitionCount:repeatCnt];
-      
+
       repeatCnt++;
       if (_reconnect)
         [self reconnect];
       repeatCommand = NO;
     }
-    
+
     NS_DURING {
       NSException *ex;
-      
+
       if ((ex = [self sendCommand:_command logText:_txt]) != nil) {
-	repeatCommand = [self handleProcessException:ex 
+	repeatCommand = [self handleProcessException:ex
 			      repetitionCount:repeatCnt];
       }
       else
@@ -764,17 +756,17 @@ static BOOL     debugImap4         = NO;
       repeatCommand = [self handleProcessException:localException
                             repetitionCount:repeatCnt];
     }
-    NS_ENDHANDLER;    
+    NS_ENDHANDLER;
   }
   while (repeatCommand);
-  
+
   if (ProfileImapEnabled) {
     gettimeofday(&tv, NULL);
     ti = (double)tv.tv_sec + ((double)tv.tv_usec / 1000000.0) - ti;
     fprintf(stderr, "}[%s] <Send Command> : time needed: %4.4fs\n",
-           __PRETTY_FUNCTION__, ti < 0.0 ? -1.0 : ti);    
+           __PRETTY_FUNCTION__, ti < 0.0 ? -1.0 : ti);
   }
-  
+
   return map;
 }
 
@@ -784,10 +776,10 @@ static BOOL     debugImap4         = NO;
 
 - (NSException *)sendCommand:(id)_command logText:(id)_txt {
   NSString *command = nil;
-  
+
   if ((command = _command) == nil) /* missing command */
     return nil; // TODO: return exception?
-  
+
   /* log */
 
   if (self->debug) {
@@ -801,17 +793,17 @@ static BOOL     debugImap4         = NO;
   }
 
   /* write */
-  
+
   if (![_command isKindOfClass:[NSData class]])
     _command = [command dataUsingEncoding:NSUTF8StringEncoding];
-  
+
   if (![self->io safeWriteData:_command])
     return [self->io lastException];
   if (![self->io writeBytes:"\r\n" count:2])
     return [self->io lastException];
   if (![self->io flush])
     return [self->io lastException];
-  
+
   return nil;
 }
 
@@ -823,7 +815,7 @@ static BOOL     debugImap4         = NO;
   NSException *ex;
   BOOL tryAgain;
   int  repeatCnt;
-  
+
   for (tryAgain = YES, repeatCnt = 0, ex = nil; tryAgain; repeatCnt++) {
     if (repeatCnt > 0) {
       if (repeatCnt > 1) /* one repeat goes without delay */
@@ -831,23 +823,23 @@ static BOOL     debugImap4         = NO;
       [self reconnect];
       tryAgain = NO;
     }
-    
+
     NS_DURING
       ex = [self sendCommand:_command logText:_txt];
     NS_HANDLER
       ex = [localException retain];
     NS_ENDHANDLER;
-    
+
     if (ex == nil) /* everything is fine */
       break;
-    
+
     if (repeatCnt > _c) /* reached max attempts */
       break;
-    
+
     /* try again for certain exceptions */
     tryAgain = [self handleProcessException:ex repetitionCount:repeatCnt];
   }
-  
+
   return ex;
 }
 
@@ -855,7 +847,7 @@ static BOOL     debugImap4         = NO;
 
 - (int)readByte {
   unsigned char c;
-  
+
   if (![self->io readBytes:&c count:1]) {
     [self setLastException:[self->io lastException]];
     return -1;
@@ -864,33 +856,33 @@ static BOOL     debugImap4         = NO;
 }
 
 - (NSString *)readLiteral {
-  /* 
+  /*
      Assumes 1st char is consumed, returns a retained string.
-     
+
      Parses: "{" number [ "+" ] "}" CRLF *OCTET
   */
   unsigned char countBuf[16];
   int      i;
   unsigned byteCount;
   unsigned char *octets;
-  
+
   /* read count */
-  
+
   for (i = 0; i < 14; i++) {
     int c;
-    
+
     if ((c = [self readByte]) == -1)
       return nil;
     if (c == '}')
       break;
-    
+
     countBuf[i] = c;
   }
   countBuf[i] = '\0';
   byteCount = i > 0 ? atoi((char *)countBuf) : 0;
-  
+
   /* read CRLF */
-  
+
   i = [self readByte];
   if (i != '\n') {
     if (i == '\r' && i != -1)
@@ -898,31 +890,31 @@ static BOOL     debugImap4         = NO;
     if (i == -1)
       return nil;
   }
-  
+
   /* read octet */
-  
+
   if (byteCount == 0)
     return @"";
-  
+
   octets = malloc(byteCount + 4);
   if (![self->io safeReadBytes:octets count:byteCount]) {
     [self setLastException:[self->io lastException]];
     return nil;
   }
   octets[byteCount] = '\0';
-  
+
   return [[NSString alloc] initWithUTF8String:(char *)octets];
 }
 
 - (NSString *)readQuoted {
-  /* 
+  /*
      assumes 1st char is consumed, returns a retained string
 
      Note: quoted strings are limited to 1KB!
   */
   unsigned char buf[1032];
   int i, c;
-  
+
   i = 0;
   do {
     c      = [self readByte];
@@ -931,32 +923,32 @@ static BOOL     debugImap4         = NO;
   }
   while ((c != -1) && (c != '"'));
   buf[i] = '\0';
-  
+
   if (c == -1)
     return nil;
-  
+
   return [[NSString alloc] initWithUTF8String:(char *)buf];
 }
 
 - (NSString *)readStringToCRLF {
   unsigned char buf[1032];
   int i, c;
-  
+
   i = 0;
   do {
     c = [self readByte];
     if (c == '\n' || c == '\r')
       break;
-    
+
     buf[i] = c;
     i++;
   }
   while ((c != -1) && (c != '\r') && (c != '\n') && (i < 1024));
   buf[i] = '\0';
-  
+
   if (c == -1)
     return nil;
-  
+
   /* consume CRLF */
   if (c == '\r') {
     if ((c = [self readByte]) != '\n') {
@@ -967,17 +959,17 @@ static BOOL     debugImap4         = NO;
       return nil;
     }
   }
-  
+
   return [[NSString alloc] initWithUTF8String:(char *)buf];
 }
 
 - (NSString *)readString {
   /* Note: returns a retained string */
   int c1;
-  
+
   if ((c1 = [self readByte]) == -1)
     return nil;
-  
+
   if (c1 == '"')
     return [self readQuoted];
   if (c1 == '{')
@@ -998,7 +990,7 @@ static BOOL     debugImap4         = NO;
 
   ms = [NSMutableString stringWithCapacity:128];
   [ms appendFormat:@"<0x%p[%@]:", self, NSStringFromClass([self class])];
-  
+
   if (self->socket != nil)
     [ms appendFormat:@" socket=%@", [self socket]];
   else

--- a/sope-mime/NGMail/NGSmtpClient.h
+++ b/sope-mime/NGMail/NGSmtpClient.h
@@ -64,6 +64,7 @@ typedef enum {
 
   BOOL useStartTLS;
   BOOL useSSL;
+  int tlsVerifyMode;
 }
 
 + (id)clientWithURL:(NSURL *)_url;

--- a/sope-mime/NGMime/NGMimeType.m
+++ b/sope-mime/NGMime/NGMimeType.m
@@ -59,7 +59,7 @@ classForType(NSString *_type, NSString *_subType, NSDictionary *_parameters)
         || [_subType isEqualToString:@"vcard"])
       return [NGConcreteTextVcardMimeType class];
   }
-  
+
   c = [typeToClass objectForKey:_type];
   return c ? c : [NGConcreteGenericMimeType class];
 }
@@ -71,13 +71,13 @@ static Class NSStringClass  = Nil;
     isInitialized = YES;
 
     typeToClass = [[NSMutableDictionary alloc] initWithCapacity:10];
-    [typeToClass setObject:[NGConcreteTextMimeType  class] 
+    [typeToClass setObject:[NGConcreteTextMimeType  class]
 		 forKey:NGMimeTypeText];
-    [typeToClass setObject:[NGConcreteVideoMimeType class] 
+    [typeToClass setObject:[NGConcreteVideoMimeType class]
 		 forKey:NGMimeTypeVideo];
-    [typeToClass setObject:[NGConcreteAudioMimeType class] 
+    [typeToClass setObject:[NGConcreteAudioMimeType class]
 		 forKey:NGMimeTypeAudio];
-    [typeToClass setObject:[NGConcreteImageMimeType class] 
+    [typeToClass setObject:[NGConcreteImageMimeType class]
 		 forKey:NGMimeTypeImage];
     [typeToClass setObject:[NGConcreteApplicationMimeType class]
                  forKey:NGMimeTypeApplication];
@@ -93,13 +93,17 @@ static Class NSStringClass  = Nil;
   NSStringEncoding encoding;
 
   charset          = [_s lowercaseString];
-  
+
   if ([charset length] == 0)
     encoding = [NSString defaultCStringEncoding];
-  
+
   /* UTF-, ASCII */
   else if ([charset isEqualToString:@"us-ascii"])
     encoding = NSASCIIStringEncoding;
+  else if ([charset isEqualToString:@"ascii"])
+    encoding = NSASCIIStringEncoding;
+  else if ([charset isEqualToString:@"utf8"])
+    encoding = NSUTF8StringEncoding;
   else if ([charset isEqualToString:@"utf-8"])
     encoding = NSUTF8StringEncoding;
   else if ([charset isEqualToString:@"utf-16"])
@@ -112,7 +116,7 @@ static Class NSStringClass  = Nil;
     encoding = NSISOLatin1StringEncoding;
   else if ([charset isEqualToString:@"8859-1"])
     encoding = NSISOLatin1StringEncoding;
-  
+
   /* some unsupported, but known encoding */
   else if ([charset isEqualToString:@"ks_c_5601-1987"]) {
     encoding = NSISOLatin1StringEncoding;
@@ -161,6 +165,9 @@ static Class NSStringClass  = Nil;
     // latin 5 is for turkish languages
     encoding = NSISOLatin5StringEncoding;
   }
+  else if ([charset isEqualToString:@"iso-8859-5"]) {
+    encoding = NSISOCyrillicStringEncoding;
+  }
   else if ([charset isEqualToString:@"x-unknown"] ||
            [charset isEqualToString:@"unknown"]) {
     encoding = NSISOLatin1StringEncoding;
@@ -191,7 +198,7 @@ static Class NSStringClass  = Nil;
 
   c = classForType(_type, _subType, _parameters);
   [self release];
-  
+
   return [[c alloc] initWithType:_type subType:_subType
                     parameters:_parameters];
 }
@@ -200,7 +207,7 @@ static Class NSStringClass  = Nil;
   Class c;
 
   c = classForType(_type, _subType, nil);
-  
+
   NSAssert(c, @"did not find class for mimetype ..");
 
   return [[[c alloc] initWithType:_type subType:_subType
@@ -214,7 +221,7 @@ static Class NSStringClass  = Nil;
 
   c = classForType(_type, _subType, _parameters);
   NSAssert(c, @"did not find class for mimetype ..");
-  
+
   return [[[c alloc] initWithType:_type subType:_subType
                      parameters:_parameters] autorelease];
 }
@@ -331,7 +338,7 @@ static Class NSStringClass  = Nil;
     ost = @"*";
   }
   if (![st isEqualToString:ost]) return NO;
-  
+
   return YES;
 }
 
@@ -373,17 +380,17 @@ static Class NSStringClass  = Nil;
 
   if ((names = [self parameterNames]) == nil)
     return nil;
-  
+
   result = [NSMutableString stringWithCapacity:64];
   while ((name = [names nextObject])) {
     NSString *value;
 
     value = [[self valueOfParameter:name] stringValue];
-    
+
     [result appendString:@"; "];
     [result appendString:name];
     [result appendString:@"="];
-    
+
     if ([self valueNeedsQuotes:value]) {
       [result appendString:@"\""];
       [result appendString:value];
@@ -514,20 +521,20 @@ static NSString *_stringForType(char *_type, int _len) {
         return MimeTypeConstants->star;
       break;
     case 4:
-      if (strncmp(_type, "text", 4) == 0) 
+      if (strncmp(_type, "text", 4) == 0)
         return MimeTypeConstants->text;
       break;
     case 5:
       if (_type[0] == 'i') {
-        if (strncmp(_type, "image", 5) == 0) 
+        if (strncmp(_type, "image", 5) == 0)
           return MimeTypeConstants->image;
       }
       else if (_type[0] == 'v') {
-        if (strncmp(_type, "video", 5) == 0) 
+        if (strncmp(_type, "video", 5) == 0)
           return MimeTypeConstants->video;
       }
       else if (_type[0] == 'a') {
-        if (strncmp(_type, "audio", 5) == 0) 
+        if (strncmp(_type, "audio", 5) == 0)
           return MimeTypeConstants->audio;
       }
       break;
@@ -577,56 +584,56 @@ static NSString *_stringForSubType(char *_type, int _len) {
       break;
     case 3:
       if (_type[0] == 'p') {
-        if (strncmp(_type, "png", 3) == 0) 
+        if (strncmp(_type, "png", 3) == 0)
           return MimeSubTypeConstants->png;
       }
       else if (_type[0] == 'g') {
-        if (strncmp(_type, "gif", 3) == 0) 
+        if (strncmp(_type, "gif", 3) == 0)
           return MimeSubTypeConstants->gif;
       }
       else if (_type[0] == 'c') {
-        if (strncmp(_type, "css", 3) == 0) 
+        if (strncmp(_type, "css", 3) == 0)
           return MimeSubTypeConstants->css;
       }
       else if (_type[0] == 'x') {
-        if (strncmp(_type, "xml", 3) == 0) 
+        if (strncmp(_type, "xml", 3) == 0)
           return MimeSubTypeConstants->xml;
       }
       break;
     case 4:
       if (_type[0] == 'h') {
-        if (strncmp(_type, "html", 4) == 0) 
+        if (strncmp(_type, "html", 4) == 0)
           return MimeSubTypeConstants->html;
       }
       else if (_type[0] == 'j') {
-        if (strncmp(_type, "jpeg", 4) == 0) 
+        if (strncmp(_type, "jpeg", 4) == 0)
           return MimeSubTypeConstants->jpeg;
       }
       break;
     case 5:
       if (_type[0] == 'p') {
-        if (strncmp(_type, "plain", 5) == 0) 
+        if (strncmp(_type, "plain", 5) == 0)
           return MimeSubTypeConstants->plain;
       }
       else if (_type[0] == 'm') {
-        if (strncmp(_type, "mixed", 5) == 0) 
+        if (strncmp(_type, "mixed", 5) == 0)
           return MimeSubTypeConstants->mixed;
       }
       else if (_type[0] == 'x') {
-        if (strncmp(_type, "x-mng", 5) == 0) 
+        if (strncmp(_type, "x-mng", 5) == 0)
           return MimeSubTypeConstants->xMng;
       }
       break;
     case 6:
-      if (strncmp(_type, "rfc822", 6) == 0) 
+      if (strncmp(_type, "rfc822", 6) == 0)
           return MimeSubTypeConstants->rfc822;
       break;
     case 9:
-      if (strncmp(_type, "xhtml+xml", 9) == 0) 
+      if (strncmp(_type, "xhtml+xml", 9) == 0)
           return MimeSubTypeConstants->xhtmlXml;
       break;
     case 12:
-      if (strncmp(_type, "octet-stream", 12) == 0) 
+      if (strncmp(_type, "octet-stream", 12) == 0)
           return MimeSubTypeConstants->octetStream;
       break;
   }
@@ -671,7 +678,7 @@ static BOOL _parseMimeType(id self, NSString *_str, NSString **type,
   {
     unsigned char     buf[len + 3];
     register unsigned i;
-    
+
     buf[len] = '\0';
     for (i = 0; i < len; i++) buf[i] = tolower(tmp[i]);
     *type = _stringForType((char *)buf, len);
@@ -688,12 +695,12 @@ static BOOL _parseMimeType(id self, NSString *_str, NSString **type,
     }
     if (len <= 0) {
       *subType = @"*";
-      return YES; // no subtype was read      
+      return YES; // no subtype was read
     }
     else {
       unsigned char     buf[len + 1];
       register unsigned i;
-      
+
       buf[len] = '\0';
       for (i = 0; i < len; i++) buf[i] = tolower(tmp[i]);
       *subType = _stringForSubType((char *)buf, len);
@@ -706,7 +713,7 @@ static BOOL _parseMimeType(id self, NSString *_str, NSString **type,
   // skip spaces
   while (isRfc822_LWSP(*cstr) && (*cstr != '\0'))
     cstr++;
-  
+
   if (*cstr == ';') // skip ';' (parameter separator)
     cstr++;
 
@@ -728,6 +735,6 @@ static BOOL _parseMimeType(id self, NSString *_str, NSString **type,
   *parameters = parseParameters(self, _str, cstr);
   if (![*parameters isNotEmpty])
     *parameters = nil;
-  
+
   return YES;
 }


### PR DESCRIPTION
Add options to SMTP, IMAP, and Sieve clients disable TLS validation for localhost or completely.

To simplify the handling the the query itself, extend NSURL with a category extension implementing `queryComponents` allowing for getting the query key/value pairs from a NSDictionary.

Also rewrite the handling of starttls, now NGActiveSSLSocket can take over getting the socket file descriptor and setting up the socket properly.

Refs [#5078](https://sogo.nu/bugs/view.php?id=5078)