### PR TITLE
fix(appserver): Fix memory leak

### DIFF
--- a/sope-appserver/NGObjWeb/WORequest.m
+++ b/sope-appserver/NGObjWeb/WORequest.m
@@ -144,7 +144,7 @@ static BOOL debugOn = NO;
       i++;
     }
 
-  return [[NSString alloc] initWithCString:start length:(o_buf - start)];
+  return [[NSString alloc] initWithCStringNoCopy:start length:(o_buf - start) freeWhenDone:YES];
 }
 
 /* parse URI */


### PR DESCRIPTION
Free the memory allocated by calloc() again by passing `freeWhenDone: YES`