### PR TITLE
fix(core): Dont leak fd when using STARTTLS

### DIFF
--- a/sope-appserver/NGObjWeb/WORequest.m
+++ b/sope-appserver/NGObjWeb/WORequest.m
@@ -63,11 +63,11 @@ static BOOL debugOn = NO;
 
   if (isInitialized) return;
   isInitialized = YES;
-  
+
   debugOn = [WOApplication isDebuggingEnabled];
-    
+
   /* apply defaults on some globals ... */
-    
+
   apath = [ud stringForKey:@"WORequestValueSessionID"];
   if ([apath isNotEmpty])
     WORequestValueSessionID = [apath copy];
@@ -77,9 +77,9 @@ static BOOL debugOn = NO;
   apath = [ud stringForKey:@"WONoSelectionString"];
   if ([apath isNotEmpty])
     WONoSelectionString = [apath copy];
-  
+
   /* load language mappings */
-    
+
   apath = [WOApplication findNGObjWebResource:@"Languages" ofType:@"plist"];
   if (apath == nil) {
     [self errorWithFormat:@"cannot find Languages.plist resource "
@@ -88,10 +88,10 @@ static BOOL debugOn = NO;
   }
   else
     langMap = [NSDictionary dictionaryWithContentsOfFile:apath];
-  
+
   if (langMap != nil) {
     NSDictionary *defs;
-    
+
     defs = [NSDictionary dictionaryWithObject:langMap
 			 forKey:@"WOBrowserLanguageMappings"];
     [ud registerDefaults:defs];
@@ -105,7 +105,8 @@ static BOOL debugOn = NO;
 - (NSString *) _sanitize: (NSString *) s
 {
   unsigned int i_len, o_len, i;
-  const char *i_buf, *start;
+  char *start;
+  const char *i_buf;
   char c, *o_buf;
 
   i_buf = [s cStringUsingEncoding: NSASCIIStringEncoding];
@@ -156,30 +157,30 @@ static BOOL debugOn = NO;
 
   // TBD: do not use cString ...
   uriLen = [self->_uri cStringLength];
-  
+
   uriBuf = uri = malloc(uriLen + 4 /* some extra safety ;-) */);
   [self->_uri getCString:uriBuf]; uriBuf[uriLen] = '\0';
-  
+
   /* determine adaptor prefix */
 
   if ((serverUrl = [self headerForKey:@"x-webobjects-adaptor-prefix"]) != nil)
     self->adaptorPrefix = [serverUrl copyWithZone:NULL];
-  
+
   if (self->adaptorPrefix == nil)
     self->adaptorPrefix = @"";
-  
+
   /* new parse */
-  
+
   if (uri != NULL) {
     const char *start = NULL;
-      
+
     /* skip adaptor prefix */
     if (self->adaptorPrefix)
       uri += [self->adaptorPrefix cStringLength];
     if (*uri == '\0') goto done;
 
     /* parse application name */
-      
+
     uri++; // skip '/'
     start = uri;
     while ((*uri != '\0') && (*uri != '/') && (*uri != '.'))
@@ -209,9 +210,9 @@ static BOOL debugOn = NO;
       goto done; // invalid state !
 
     if (*uri == '\0') goto done;
-    
+
     /* parse request handler key */
-    
+
     start = uri;
     while ((*uri != '\0') && (*uri != '/') && (*uri != '?'))
       uri++;
@@ -221,14 +222,14 @@ static BOOL debugOn = NO;
     if(*uri == '/'){
       uri++; // skip '/'
       /* parse request handler path */
-      
+
       start = uri;
       while (*uri != '\0' && (*uri != '?'))
         uri++;
       self->requestHandlerPath =
         [[NSString alloc] initWithCString:start length:(uri - start)];
     }
-    
+
     /* parsing done (found '\0') */
   done:
     ; // required for MacOSX-S
@@ -247,7 +248,7 @@ static BOOL debugOn = NO;
     self->_uri   = [self _sanitize: __uri];
     self->method = [_method copy];
     [self _parseURI];
-    
+
     /* WOMessage */
     [self setHTTPVersion:_version];
     [self setContent:_body];
@@ -309,21 +310,21 @@ static BOOL debugOn = NO;
   unsigned       clen;
   char           *cstrBuf;
   register char  *cstr;
-  
+
   clen   = [self->requestHandlerPath cStringLength];
   if (clen == 0)
     return nil;
-  
+
   cstrBuf = cstr = malloc(clen + 1);
   [self->requestHandlerPath getCString:cstrBuf]; cstrBuf[clen] = '\0';
-  
+
   do {
     NSString *component = nil;
     register char *tmp = cstr;
 
     while ((*tmp != '\0') && (*tmp != '?') && (*tmp != '/'))
       tmp++;
-    
+
     component = ((tmp - cstr) == 0)
       ? (id)@""
       : [[NSString alloc] initWithCString:cstr length:(tmp - cstr)];
@@ -421,12 +422,12 @@ static BOOL debugOn = NO;
 - (void)_parseQueryParameters:(NSString *)_s intoMap:(NGMutableHashMap *)_map {
   NSEnumerator *e;
   NSString *part;
-  
+
   e = [[_s componentsSeparatedByString:@"&"] objectEnumerator];
   while ((part = [e nextObject])) {
     NSRange  r;
     NSString *key, *value;
-	  
+
     r = [part rangeOfString:@"="];
     if (r.length == 0) {
       /* missing value of query parameter */
@@ -435,30 +436,30 @@ static BOOL debugOn = NO;
     }
     else {
       key   = [[part substringToIndex:r.location] stringByUnescapingURL];
-      value = [[part substringFromIndex:(r.location + r.length)] 
+      value = [[part substringFromIndex:(r.location + r.length)]
 		     stringByUnescapingURL];
     }
-    
+
     [self->formContent addObject:value forKey:key];
   }
 }
 
 - (NGHashMap *)_getFormParameters {
-  if (self->formContent != nil) 
+  if (self->formContent != nil)
     return self->formContent;
-  
+
   if (self->request != nil) {
     self->formContent = [[self->request formParameters] retain];
     return self->formContent;
   }
-  
+
   {
     /*
       TODO: add parsing of form values
-      
+
       contained in URL:
         a/blah?name=login&pwd=j
-      
+
       contained in body:
         Content-Type: application/x-www-form-urlencoded
         browserconfig=%7BisJavaScriptEnabled%3DYES%3B%7D&login=r&button=login
@@ -467,28 +468,28 @@ static BOOL debugOn = NO;
     NSString *query;
     NSString *ctype;
     BOOL     isMultiPartContent = NO, isFormContent = NO;
-    
+
     r = [self->_uri rangeOfString:@"?"];
     query = (r.length > 0)
       ? [self->_uri substringFromIndex:(r.location + r.length)]
       : (NSString *)nil;
-    
+
     if ((ctype = [self headerForKey:@"content-type"]) != nil) {
       isFormContent = [ctype hasPrefix:@"application/x-www-form-urlencoded"];
       if (!isFormContent)
         isMultiPartContent = [ctype hasPrefix:@"multipart/form-data"];
     }
-    
+
     if (query != nil || isFormContent || isMultiPartContent) {
       NSAutoreleasePool *pool;
-      
+
       pool = [[NSAutoreleasePool alloc] init];
       self->formContent = [[NGMutableHashMap alloc] init];
-      
+
       /* parse query string */
       if (query)
         [self _parseQueryParameters:query intoMap:self->formContent];
-      
+
       /* parse content (if form content) */
       if (isFormContent) {
         [self _parseQueryParameters:[self contentAsString]
@@ -497,7 +498,7 @@ static BOOL debugOn = NO;
       else if (isMultiPartContent) {
         [self errorWithFormat:@"missing NGHttpRequest, cannot parse multipart"];
       }
-      
+
       [pool release];
     }
     else
@@ -508,22 +509,22 @@ static BOOL debugOn = NO;
 
 - (NSArray *)formValueKeys {
   id paras = [self _getFormParameters];
-  
+
   if ([paras respondsToSelector:@selector(allKeys)])
     return [paras allKeys];
-  
+
   return nil;
 }
 
 - (NSString *)formValueForKey:(NSString *)_key {
   NSString *value;
   id paras;
-  
+
   value = nil;
   paras = [self _getFormParameters];
   if ([paras respondsToSelector:@selector(objectForKey:)])
     value = [(NSDictionary *)paras objectForKey:_key];
-  
+
   return value;
 }
 - (NSArray *)formValuesForKey:(NSString *)_key {
@@ -535,17 +536,17 @@ static BOOL debugOn = NO;
 
 - (NSDictionary *)formValues {
   id paras;
-  
+
   if ((paras = [self _getFormParameters]) == nil)
     return nil;
-  
+
   /* check class, could change with different HTTP adaptor */
-  
+
   if ([paras isKindOfClass:[NGHashMap class]])
     return [paras asDictionaryWithArraysForValues];
   if ([paras isKindOfClass:[NSDictionary class]])
     return paras;
-  
+
   [self errorWithFormat:@"(%s): don't know how to deal with form object: %@",
           paras];
   return nil;
@@ -556,26 +557,26 @@ static BOOL debugOn = NO;
 - (NSString *)languageForBrowserLanguageCode:(NSString *)_e {
   static NSDictionary *langMap = nil;
   NSString *le, *lang;
-  
+
   if (_e == nil) return nil;
-  
+
   if (langMap == nil) {
     NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
-    
+
     langMap = [[ud dictionaryForKey:@"WOBrowserLanguageMappings"] copy];
     if (langMap == nil) {
       [self warnWithFormat:@"did not find browser language mappings!"];
     }
   }
-  
+
   le = [_e lowercaseString];
-  
+
   lang = [langMap objectForKey:le];
   if (lang == nil && [le length] > 2) {
     /* process constructs like 'de-ch' */
     if ([le characterAtIndex:2] == '-') {
       NSString *ek;
-      
+
       ek = [le substringToIndex:2];
       lang = [langMap objectForKey:ek];
     }
@@ -589,7 +590,7 @@ static BOOL debugOn = NO;
     }
   }
   if (lang == nil && ![_e isEqualToString:@"*"]) {
-    [self debugWithFormat:@"did not find '%@' in map: %@", 
+    [self debugWithFormat:@"did not find '%@' in map: %@",
 	    _e, [[langMap allKeys] componentsJoinedByString:@", "]];
   }
   return lang;
@@ -603,14 +604,14 @@ static BOOL debugOn = NO;
   NSString *ua;
   NSRange  rng;
   NSString *tmp;
-  
+
   if ((ua = [self headerForKey:@"user-agent"]) == nil)
     return nil;
 
   rng = [ua rangeOfString:@"["];
   if (rng.length == 0)
     return nil;
-      
+
   tmp = [ua substringFromIndex:(rng.location + rng.length)];
   rng = [tmp rangeOfString:@"]"];
   if (rng.length > 0)
@@ -625,20 +626,20 @@ static BOOL debugOn = NO;
   NSEnumerator   *e;
   NSString       *language;
   NSString       *tmp;
-  
+
   if (!browserLanguages)
     {
       browserLanguages = [NSMutableArray new];
-  
+
       e = [[self headersForKey:@"accept-language"] objectEnumerator];
       while ((hheader = [e nextObject]) != nil) {
         NSEnumerator *le;
-    
+
         le = [[hheader componentsSeparatedByString:@","] objectEnumerator];
         while ((language = [le nextObject]) != nil) {
           NSString *tmp;
           NSRange  r;
-      
+
           /* split off the quality (eg 'en;0.96') */
           r = [language rangeOfString:@";"];
           if (r.length > 0)
@@ -647,28 +648,28 @@ static BOOL debugOn = NO;
 
           if ([language length] == 0)
             continue;
-      
+
           /* check in map */
           if ((tmp = [self languageForBrowserLanguageCode:language]))
             language = tmp;
-      
+
           if ([browserLanguages containsObject:language])
             continue;
-      
+
           [browserLanguages addObject:language];
         }
       }
-  
+
       if ((tmp = [self _languageFromUserAgent]))
         [browserLanguages addObject:tmp];
-  
+
       if (defLangs == nil) {
         NSUserDefaults *ud = [NSUserDefaults standardUserDefaults];
         defLangs = [[ud arrayForKey:@"WODefaultLanguages"] copy];
       }
       [browserLanguages addObjectsFromArray:defLangs];
     }
-  
+
   //[self debugWithFormat:@"languages: %@", languages];
   return browserLanguages;
 }
@@ -679,22 +680,22 @@ static BOOL debugOn = NO;
   NSEnumerator   *ecookies;
   NSMutableArray *values;
   WOCookie       *cookie;
-  
+
   values  = [NSMutableArray arrayWithCapacity:8];
-  
+
   ecookies = [[self cookies] objectEnumerator];
   while ((cookie = [ecookies nextObject])) {
     if ([_key isEqualToString:[cookie name]])
       [values addObject:[cookie value]];
   }
-  
+
   return values;
 }
 
 - (NSString *)cookieValueForKey:(NSString *)_key {
   NSEnumerator *ecookies;
   WOCookie     *cookie;
-  
+
   ecookies = [[self cookies] objectEnumerator];
   while ((cookie = [ecookies nextObject])) {
     if ([_key isEqualToString:[cookie name]])
@@ -707,26 +708,26 @@ static BOOL debugOn = NO;
   NSEnumerator        *ecookies;
   NSMutableDictionary *values;
   WOCookie            *cookie;
-  
+
   values  = [NSMutableDictionary dictionaryWithCapacity:8];
-  
+
   ecookies = [[self cookies] objectEnumerator];
   while ((cookie = [ecookies nextObject])) {
     NSString       *name;
     NSMutableArray *vArray;
-    
+
     name   = [cookie name];
     vArray = [values objectForKey:name];
-    
+
     if (vArray == nil) {
       vArray = [[NSMutableArray alloc] initWithCapacity:8];
       [values setObject:vArray forKey:name];
       [vArray release];
     }
-    
+
     [vArray addObject:[cookie value]];
   }
-  
+
   return values;
 }
 
@@ -734,7 +735,7 @@ static BOOL debugOn = NO;
 
 - (NSString *)fragmentID {
   NSString *v;
-  
+
   v = [self formValueForKey:WORequestValueFragmentID];
   if (v == nil) return nil;
   v = [v stringByTrimmingWhiteSpaces];
@@ -751,7 +752,7 @@ static BOOL debugOn = NO;
   return debugOn;
 }
 - (NSString *)loggingPrefix {
-  return [NSString stringWithFormat:@"|Rq:%@ 0x%p|", 
+  return [NSString stringWithFormat:@"|Rq:%@ 0x%p|",
                      [self method], self];
 }
 

--- a/sope-core/NGStreams/NGActiveSSLSocket.m
+++ b/sope-core/NGStreams/NGActiveSSLSocket.m
@@ -147,7 +147,8 @@ DEALINGS IN THE SOFTWARE.
   }
 
   sock_fd = [_socket fileDescriptor];
-  [self setFileDescriptor: sock_fd];
+  // the fd is still owned by the other socket
+  [self setFileDescriptor: sock_fd closeWhenDone: NO];
   // We remove the NON-BLOCKING I/O flag on the file descriptor, otherwise
   // SOPE will break on SSL-sockets.
   oldopts = fcntl(sock_fd, F_GETFL, 0);

--- a/sope-core/NGStreams/NGActiveSocket.m
+++ b/sope-core/NGStreams/NGActiveSocket.m
@@ -102,7 +102,7 @@
     NGActiveSocket *s1 = nil;
     NGActiveSocket *s2 = nil;
     NGLocalSocketAddress *address;
-    
+
     s1 = [[self alloc] _initWithDomain:domain descriptor:fds[0]];
     s2 = [[self alloc] _initWithDomain:domain descriptor:fds[1]];
     s1 = [s1 autorelease];
@@ -173,7 +173,7 @@
 
 + (id)socketConnectedToAddress:(id<NGSocketAddress>)_address {
   volatile id sock = [[self alloc] initWithDomain:[_address domain]];
-  
+
   if (sock != nil) {
     if (![sock connectToAddress:_address]) {
       NSException *e;
@@ -208,13 +208,13 @@
 
 - (id)_initWithDescriptor:(int)_fd
   localAddress:(id<NGSocketAddress>)_local
-  remoteAddress:(id<NGSocketAddress>)_remote 
+  remoteAddress:(id<NGSocketAddress>)_remote
 {
   if ((self = [self _initWithDomain:[_local domain] descriptor:_fd])) {
     ASSIGN(self->localAddress,  _local);
     ASSIGN(self->remoteAddress, _remote);
     self->mode = NGStreamMode_readWrite;
-    
+
 #if !defined(WIN32) || defined(__CYGWIN32__)
     NGAddDescriptorFlag(self->fd, O_NONBLOCK);
 #endif
@@ -236,10 +236,10 @@
 - (void)raise:(NSString *)_name reason:(NSString *)_reason {
   Class clazz;
   NSException *e;
-  
+
   clazz = NSClassFromString(_name);
   NSAssert1(clazz, @"did not find exception class %@", _name);
-  
+
   e = [clazz alloc];
   if (_reason) {
     if ([clazz instancesRespondToSelector:@selector(initWithReason:socket:)])
@@ -283,14 +283,14 @@
   //   NGCouldNotConnectException  if the the connect() call fails
 
   [self resetLastException];
-  
+
   if (connect(fd,
               (struct sockaddr *)[_address internalAddressRepresentation],
               [_address addressRepresentationSize]) != 0) {
     NSString *reason   = nil;
     int      errorCode = errno;
     NSException *e;
-    
+
     switch (errorCode) {
       case EACCES:
         reason = @"search permission denied for element in path";
@@ -373,7 +373,7 @@
         NSLog(@"WARNING(%s): connect() call failed, but errno=0",
               __PRETTY_FUNCTION__);
 #endif
-        
+
       default:
         reason = [NSString stringWithCString:strerror(errorCode)];
         break;
@@ -381,14 +381,14 @@
 
     reason = [NSString stringWithFormat:@"Could not connect to address %@: %@",
                          _address, reason];
-    
+
     e = [[NGCouldNotConnectException alloc]
               initWithReason:reason socket:self address:_address];
     [self setLastException:e];
     [e release];
     return NO;
   }
-  
+
   /* connect was successful */
 
   ASSIGN(self->remoteAddress, _address);
@@ -407,7 +407,7 @@
   //   NGSocketAlreadyConnectedException  if the socket is already connected
   //   NGInvalidSocketDomainException     if the remote domain != local domain
   //   NGCouldNotCreateSocketException    if the socket creation failed
-  
+
   if ([self isConnected]) {
     [[[NGSocketAlreadyConnectedException alloc]
               initWithReason:@"Could not connected: socket is already connected"
@@ -424,7 +424,7 @@
       return NO;
     }
   }
-  
+
   // connect, remote-address is non-nil if this returns
   if (![self primaryConnectToAddress:_address])
     return NO;
@@ -445,20 +445,24 @@
       if (shutdown(self->fd, SHUT_RDWR) == 0)
         self->mode = NGStreamMode_undefined;
     }
-    
+
+    if (self->flags.closeOnFree) {
 #if defined(WIN32) && !defined(__CYGWIN32__)
-    if (closesocket(self->fd) == 0) {
+      if (closesocket(self->fd) == 0) {
 #else
-    if (close(self->fd) == 0) {
+      if (close(self->fd) == 0) {
 #endif
+        self->fd = NGInvalidSocketDescriptor;
+      }
+      else {
+        NSLog(@"ERROR(%s): close of socket %@ (fd=%i) alive=%s failed: %s",
+              __PRETTY_FUNCTION__,
+              self, self->fd, [self isAlive] ? "YES" : "NO", strerror(errno));
+      }
+    } else {
       self->fd = NGInvalidSocketDescriptor;
     }
-    else {
-      NSLog(@"ERROR(%s): close of socket %@ (fd=%i) alive=%s failed: %s",
-            __PRETTY_FUNCTION__,
-            self, self->fd, [self isAlive] ? "YES" : "NO", strerror(errno));
-    }
-    
+
     ASSIGN(self->remoteAddress, (id)nil);
   }
   return YES;
@@ -467,16 +471,18 @@
 - (BOOL)shutdownSendChannel {
   if (NGCanWriteInStreamMode(self->mode)) {
     shutdown(self->fd, SHUT_WR);
-    
+
     if (self->mode == NGStreamMode_readWrite)
       self->mode = NGStreamMode_readOnly;
     else {
       self->mode = NGStreamMode_undefined;
+      if (self->flags.closeOnFree) {
 #if defined(WIN32) && !defined(__CYGWIN32__)
-      closesocket(self->fd);
+        closesocket(self->fd);
 #else
-      close(self->fd);
+        close(self->fd);
 #endif
+      }
       self->fd = NGInvalidSocketDescriptor;
     }
   }
@@ -485,16 +491,18 @@
 - (BOOL)shutdownReceiveChannel {
   if (NGCanReadInStreamMode(self->mode)) {
     shutdown(self->fd, SHUT_RD);
-    
+
     if (self->mode == NGStreamMode_readWrite)
       self->mode = NGStreamMode_writeOnly;
     else {
       self->mode = NGStreamMode_undefined;
+      if (self->flags.closeOnFree) {
 #if defined(WIN32) && !defined(__CYGWIN32__)
-      closesocket(self->fd);
+        closesocket(self->fd);
 #else
-      close(self->fd);
+        close(self->fd);
 #endif
+      }
       self->fd = NGInvalidSocketDescriptor;
     }
   }
@@ -588,16 +596,16 @@
           reason:@"socket is not connected"];
     return NGStreamError;
   }
-  
+
   if (!NGCanReadInStreamMode(self->mode)) {
     [self raise:@"NGWriteOnlyStreamException"];
     return NGStreamError;
   }
-  
+
 #if !defined(WIN32) && !defined(__CYGWIN32__)
   while (ioctl(self->fd, FIONREAD, &len) == -1) {
     if (errno == EINTR) continue;
-    
+
     [self raise:@"NGSocketException"
           reason:@"could not get number of available bytes"];
     return NGStreamError;
@@ -612,7 +620,7 @@
 - (BOOL)isAlive {
   if (self->fd == NGInvalidSocketDescriptor)
     return NO;
-  
+
   /* poll socket for input */
 #if 1
   {
@@ -649,7 +657,7 @@
       FD_ZERO(&readMask);
       FD_SET(self->fd, &readMask);
       to.tv_sec = to.tv_usec = 0;
-      
+
       if (select(self->fd + 1, &readMask, NULL, NULL, &to) >= 0)
         break;
 
@@ -663,7 +671,7 @@
     }
 
     /* no input is pending, connection is alive */
-    if (!FD_ISSET(self->fd, &readMask)) 
+    if (!FD_ISSET(self->fd, &readMask))
       return YES;
   }
 #endif
@@ -684,7 +692,7 @@
     }
     if (len > 0) return YES;
   }
-  
+
  notAlive:
   /* valid descriptor, but not alive .. so we close the socket */
 #if defined(WIN32) && !defined(__CYGWIN32__)
@@ -696,7 +704,7 @@
   DESTROY(self->remoteAddress);
   return NO;
 }
- 
+
 // ******************** NGStream ********************
 
 - (unsigned)readBytes:(void *)_buf count:(unsigned)_len {
@@ -706,24 +714,24 @@
   //   NGEndOfStreamException        when the end of the stream is reached
   //   NGWriteOnlyStreamException    when the receive channel was shutdown
   NSException *e = nil;
-  
+
   if (self->fd == NGInvalidSocketDescriptor) {
     [self raise:@"NGSocketException" reason:@"NGActiveSocket is not open"];
     return NGStreamError;
   }
-  
+
   // need to check whether socket is connected
   if (self->remoteAddress == nil) {
     [self raise:@"NGSocketNotConnectedException"
           reason:@"socket is not connected"];
     return NGStreamError;
   }
-  
+
   if (!NGCanReadInStreamMode(self->mode)) {
     [self raise:@"NGWriteOnlyStreamException"];
     return NGStreamError;
   }
-  
+
   if (_len == 0) return 0;
 
   {
@@ -738,7 +746,7 @@
     }
     else if (readResult < 0) {
       int errorCode = WSAGetLastError();
-      
+
       switch (errorCode) {
         case WSAECONNRESET:
           e = [[NGSocketConnectionResetException alloc] initWithStream:self];
@@ -749,7 +757,7 @@
 
         case WSAEWOULDBLOCK:
           NSLog(@"WARNING: descriptor would block ..");
-          
+
         default:
           e = [[NGStreamReadErrorException alloc]
                     initWithStream:self errorCode:errorCode];
@@ -766,7 +774,7 @@
 
     NSAssert(_buf,     @"invalid buffer");
     NSAssert1(_len > 0, @"invalid length: %i", _len);
-   retry: 
+   retry:
     readResult = NGDescriptorRecv(self->fd, _buf, _len, 0,
                                   (self->receiveTimeout == 0.0)
                                   ? -1 // block until data
@@ -778,7 +786,7 @@
             self->fd, _buf, _len, 0);
     }
 #endif
-    
+
     if (readResult == 0) {
       [self _shutdownDuringOperation];
       [self raise:@"NGSocketShutdownDuringReadException"];
@@ -801,7 +809,7 @@
 #endif
           goto retry;
           break;
-          
+
         case ECONNRESET:
           e = [[NGSocketConnectionResetException alloc] initWithStream:self];
           break;
@@ -811,7 +819,7 @@
 
         case EWOULDBLOCK:
           NSLog(@"WARNING: descriptor would block ..");
-          
+
         default:
           e = [[NGStreamReadErrorException alloc]
                     initWithStream:self errorCode:errorCode];
@@ -836,7 +844,7 @@
     int writeResult;
 
     writeResult = send(self->fd, _buf, _len, 0);
-    
+
     if (writeResult == 0) {
       [self _shutdownDuringOperation];
       [self raise:@"NGSocketShutdownDuringWriteException"];
@@ -844,7 +852,7 @@
     }
     else if (writeResult < 0) {
       int errorCode = WSAGetLastError();
-      
+
       switch (errorCode) {
         case WSAECONNRESET:
           e = [[NGSocketConnectionResetException alloc] initWithStream:self];
@@ -870,7 +878,7 @@
     return writeResult;
 }
 
-#else 
+#else
 
 - (unsigned)_unixWriteBytes:(const void *)_buf count:(unsigned)_len {
    int writeResult;
@@ -881,10 +889,10 @@
    timeOut = (self->sendTimeout == 0.0)
      ? -1 // block until data
      : (int)(self->sendTimeout * 1000.0);
-   
- wretry: 
+
+ wretry:
    writeResult = NGDescriptorSend(self->fd, _buf, _len, MSG_NOSIGNAL, timeOut);
-   
+
    if (writeResult == 0) {
      [self _shutdownDuringOperation];
      [self raise:@"NGSocketShutdownDuringWriteException"];
@@ -896,7 +904,7 @@
    }
    else if (writeResult < 0) {
      int errorCode = errno;
-     
+
      switch (errorCode) {
        case 0:
 #if DEBUG
@@ -917,22 +925,22 @@
          sleep(retryCount);
          goto wretry;
          break;
-         
+
        case ECONNRESET:
          [self raise:@"NGSocketConnectionResetException"];
          return NGStreamError;
        case ETIMEDOUT:
          [self raise:@"NGSocketTimedOutException"];
          return NGStreamError;
-         
+
        case EPIPE:
          [self _shutdownDuringOperation];
          [self raise:@"NGSocketShutdownDuringWriteException"];
          return NGStreamError;
-         
+
        case EWOULDBLOCK:
          NSLog(@"WARNING: descriptor would block ..");
-         
+
        default: {
          NSException *e;
          e = [[NGStreamWriteErrorException alloc]
@@ -946,14 +954,14 @@
    return writeResult;
 }
 
-#endif 
- 
+#endif
+
 - (unsigned)writeBytes:(const void *)_buf count:(unsigned)_len {
   // throws
   //   NGStreamWriteErrorException   when the write call failed
   //   NGSocketNotConnectedException when the socket is not connected
   //   NGReadOnlyStreamException     when the send channel was shutdown
-  
+
   if (_len == NGStreamError) {
     NSLog(@"ERROR(%s): got NGStreamError passed in as length ...",
           __PRETTY_FUNCTION__);
@@ -965,26 +973,26 @@
           __PRETTY_FUNCTION__, (_len / 1024 / 1024), _len, NGStreamError);
   }
 #endif
-  
+
   if (self->fd == NGInvalidSocketDescriptor) {
     [self raise:@"NGSocketException" reason:@"NGActiveSocket is not open"];
     return NGStreamError;
   }
-  
+
   // need to check whether socket is connected
   if (self->remoteAddress == nil) {
     [self raise:@"NGSocketNotConnectedException"
           reason:@"socket is not connected"];
     return NGStreamError;
   }
-  
+
   if (!NGCanWriteInStreamMode(self->mode)) {
     [self raise:@"NGReadOnlyStreamException"];
     return NGStreamError;
   }
-  
+
   //NSLog(@"writeBytes: count:%u", _len);
-  
+
 #if defined(WIN32) && !defined(__CYGWIN32__)
   return [self _winWriteBytes:_buf count:_len];
 #else
@@ -995,11 +1003,11 @@
 - (BOOL)flush {
   return YES;
 }
-#if 0 
+#if 0
 - (BOOL)close {
   return [self shutdown];
 }
-#endif 
+#endif
 
 - (NGStreamMode)mode {
   return self->mode;
@@ -1017,17 +1025,17 @@
   *(&toBeRead)   = _len;
   *(&readResult) = 0;
   *(&pos)        = _buf;
-  
+
   while (YES) {
     *(&readResult) =
       readBytes(self, @selector(readBytes:count:), pos, toBeRead);
-    
+
     if (readResult == NGStreamError) {
       NSException *localException;
       NSData *data;
-      
+
       data = [NSData dataWithBytes:_buf length:(_len - toBeRead)];
-      
+
       localException = [[NGEndOfStreamException alloc]
                           initWithStream:self
                           readCount:(_len - toBeRead)
@@ -1036,14 +1044,14 @@
       [self setLastException:localException];
       RELEASE(localException);
     }
-    
+
     NSAssert(readResult != 0, @"ERROR: readBytes may not return '0' ..");
 
     if (readResult == toBeRead) {
       // all bytes were read successfully, return
       break;
     }
-    
+
     if (readResult < 1) {
       [NSException raise:NSInternalInconsistencyException
                    format:@"readBytes:count: returned a value < 1"];
@@ -1052,7 +1060,7 @@
     toBeRead -= readResult;
     pos      += readResult;
   }
-  
+
   return YES;
 }
 
@@ -1074,11 +1082,11 @@
     lastClass = *(Class *)self;
     writeBytes = (void *)[self methodForSelector:@selector(writeBytes:count:)];
   }
-  
+
   while (YES) {
     writeResult =
       (int)writeBytes(self, @selector(writeBytes:count:), pos, toBeWritten);
-    
+
     if (writeResult == NGStreamError) {
       /* remember number of written bytes ??? */
       return NO;
@@ -1094,7 +1102,7 @@
                      self];
       return NO;
     }
-    
+
     toBeWritten -= writeResult;
     pos         += writeResult;
   }
@@ -1117,18 +1125,18 @@
 - (int)readByte { // java semantics (-1 returned on EOF)
   int result;
   unsigned char c;
-  
+
   result = [self readBytes:&c count:sizeof(unsigned char)];
-  
+
   if (result != 1) {
     static Class EOFExcClass = Nil;
 
     if (EOFExcClass == Nil)
       EOFExcClass = [NGEndOfStreamException class];
-    
+
     if ([[self lastException] isKindOfClass:EOFExcClass])
       [self resetLastException];
-    
+
     return -1;
   }
   return (int)c;
@@ -1138,7 +1146,7 @@
 
 - (NSString *)modeDescription {
   NSString *result = @"<unknown>";
-  
+
   switch ([self mode]) {
     case NGStreamMode_undefined: result = @"<closed>"; break;
     case NGStreamMode_readOnly:  result = @"r";        break;
@@ -1161,9 +1169,9 @@
   if ([self isConnected])
     [d appendFormat:@" connectedTo=%@", [self remoteAddress]];
 
-  if ([self sendTimeout] != 0.0) 
+  if ([self sendTimeout] != 0.0)
     [d appendFormat:@" send-timeout=%4.3fs", [self sendTimeout]];
-  if ([self receiveTimeout] != 0.0) 
+  if ([self receiveTimeout] != 0.0)
     [d appendFormat:@" receive-timeout=%4.3fs", [self receiveTimeout]];
 
   [d appendString:@">"];

--- a/sope-core/NGStreams/NGStreams/NGSocket.h
+++ b/sope-core/NGStreams/NGStreams/NGSocket.h
@@ -81,7 +81,7 @@
     int closeOnFree:1; // close socket on collect/dealloc ?
     int isBound:1;     // was a bind issued (either by the kernel or explicitly)
   } flags;
-  
+
   NSException *lastException;
 }
 
@@ -120,7 +120,7 @@
 - (SOCKET)fileDescriptor;
 #else
 - (int)fileDescriptor;
-- (void)setFileDescriptor: (int) theFd;
+- (void)setFileDescriptor: (int) theFd closeWhenDone: (BOOL) closeFd;
 #endif
 
 // ************************* options *************************


### PR DESCRIPTION
When STARTTLS is used, we re-use the connection and put a
new socket "on top" of the old one and reuse the file
descriptor of the previous socket.

This lead to two issues: First, now both sockets tried to close
the underlying file descriptor: Once from the non-starttls connection,
once by the starttls connection. This wasnt so harmful, as closing would
fail with EBADF. Fix this by using the flag `closeOnFree` for such
fd assignments, in this way the ownership is clearer.

The second issue is more severe: when passing the fd to the TLS socket,
the TLS socket could already have an fd assigned, but that would never
be freed. To fix the fd leak simply call `close` on the old fd
when `setFileDescriptor` is called.

Fixes: [#5175](https://sogo.nu/bugs/view.php?id=5175)