### PR TITLE
Change encoding for ks_c_5601-1987 to NSKoreanEUC

### DIFF
--- a/sope-mime/NGMime/NGMimeType.m
+++ b/sope-mime/NGMime/NGMimeType.m
@@ -119,7 +119,7 @@ static Class NSStringClass  = Nil;
 
   /* some unsupported, but known encoding */
   else if ([charset isEqualToString:@"ks_c_5601-1987"]) {
-    encoding = NSISOLatin1StringEncoding;
+    encoding = NSKoreanEUCStringEncoding;
   }
   else if ([charset isEqualToString:@"euc-kr"]) {
     encoding = NSKoreanEUCStringEncoding;


### PR DESCRIPTION
버그 위치: sope-mime/NGMime/NGMimeType.m L120
수정: NSISOLatin1StringEncoding → NSKoreanEUCStringEncoding (한 줄 변경) 재현 방법, 영향도, diff 수정안 모두 포함