### PR TITLE
fix(imap4): accept SORT data when server returns tagged NO

### DIFF
--- a/sope-mime/NGImap4/NGImap4ResponseNormalizer.m
+++ b/sope-mime/NGImap4/NGImap4ResponseNormalizer.m
@@ -129,15 +129,28 @@ static int      LogImapEnabled = -1;
 }
 
 - (NSDictionary *)normalizeSortResponse:(NGHashMap *)_map {
-  /* filter for sort response (search  : NSArray (msn)) */
+  /*
+    Filter for sort response (sort: NSArray of UIDs).
+
+    Some IMAP servers (e.g. Dovecot) may return SORT data in an untagged
+    response but then send a tagged NO (e.g. "sort would have taken too
+    long").  The data is still valid, so if we received sort results we
+    treat the command as successful regardless of the tagged status.
+  */
   id                  obj;
   NSMutableDictionary *result;
 
   result = [self normalizeResponse:_map];
-  
-  if ((obj = [[_map objectEnumeratorForKey:@"sort"] nextObject]) != nil)
+
+  if ((obj = [[_map objectEnumeratorForKey:@"sort"] nextObject]) != nil) {
     [result setObject:obj forKey:@"sort"];
-  
+
+    /* Promote to success when sort data was returned despite a tagged NO */
+    if (![[result objectForKey:@"result"] boolValue]) {
+      [result setObject:[NSNumber numberWithBool:YES] forKey:@"result"];
+    }
+  }
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

- Dovecot may return valid SORT results in an untagged `* SORT` response but then send a tagged `NO` (e.g. *"Requested sort would have taken too long"*)
- The sort data is still complete and usable — Dovecot delivers all UIDs before rejecting the command
- Previously, `normalizeSortResponse` relied solely on the tagged response status, discarding perfectly good sort data
- This caused SOGo's mail view to fail with `could not sort contents of URL` on large mailboxes (2000+ messages) served by Dovecot instances with aggressive sort-time policies

## Fix

If sort data was received in the untagged response, promote the result to success regardless of the tagged status. This is a minimal, safe change — it only affects the SORT normalizer and only when data was actually returned.

## Reproduction

1. Configure SOGo with a Dovecot IMAP server that has `mail_sort_max_time` or similar policy limits
2. Have a mailbox with 2000+ messages
3. Open the mail tab — SOGo sends `UID SORT (REVERSE ARRIVAL) UTF-8 NOT DELETED`
4. Dovecot returns `* SORT <all UIDs>` followed by tagged `NO Requested sort would have taken too long`
5. SOGo fails to display the mailbox

## Test plan

- [ ] Verify mail tab loads on large mailboxes with Dovecot
- [ ] Verify normal SORT (tagged OK) still works
- [ ] Verify SORT with no data + tagged NO still returns failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)