### PR TITLE
Fix QRESYNC VANISHED fetch for highest expunged UID

### DIFF
--- a/sope-mime/NGImap4/NGImap4Client.m
+++ b/sope-mime/NGImap4/NGImap4Client.m
@@ -1255,7 +1255,7 @@ static NSMutableDictionary *namespaces;
   pool = [[NSAutoreleasePool alloc] init];
 
   cmd  = [NSString stringWithFormat:
-                     @"UID FETCH 1:* (UID) (CHANGEDSINCE %llu VANISHED)",
+                     @"UID FETCH 1:4294967295 (UID) (CHANGEDSINCE %llu VANISHED)",
                    (unsigned long long)_modseq];
   fetchres = [self processCommand:cmd];
   result   = [[self->normer normalizeFetchResponse:fetchres] retain];


### PR DESCRIPTION
This fixes an ActiveSync/QRESYNC issue where externally expunged messages may not be detected when using Cyrus IMAP as backend.

SOGo/SOPE currently detects VANISHED messages using:

UID FETCH 1:* (UID) (CHANGEDSINCE <modseq> VANISHED)

With Cyrus IMAP, * is resolved to the highest currently visible UID in the mailbox. If the expunged message previously had the highest UID, it is now above the resolved 1:* range and Cyrus returns no VANISHED response.

As a result, SOGo does not emit a delete command to the ActiveSync client, but the SyncKey is still advanced past the expunge modseq. The deletion is then permanently missed by the device until a full folder resync.

Using an explicit maximum UID range fixes this:

UID FETCH 1:4294967295 (UID) (CHANGEDSINCE <modseq> VANISHED)

Tested with:

SOGo 5.x nightly
Cyrus IMAP 3.8.2
iOS/iPadOS Mail as ActiveSync client

This reliably fixes deletions and moves performed outside of ActiveSync, for example via IMAP or the SOGo web UI.

I have also opened a corresponding Cyrus IMAP issue for the backend-side behavior:

https://github.com/cyrusimap/cyrus-imapd/issues/6071