### PR TITLE
Fix encoding with libxml2 >= 2.12 push parser

### DIFF
--- a/sope-xml/libxmlSAXDriver/libxmlHTMLSAXDriver.m
+++ b/sope-xml/libxmlSAXDriver/libxmlHTMLSAXDriver.m
@@ -29,6 +29,7 @@
 
 #include <libxml/HTMLparser.h>
 #include <libxml/HTMLtree.h>
+#include <libxml/parserInternals.h>
 
 @interface NSObject(contentHandlerExtensions)
 
@@ -248,6 +249,15 @@ static void setLocator(void *udata, xmlSAXLocatorPtr _locator);
                                         0                /* chunklen */,
                                         [_path cString]  /* filename */,
                                         charEncoding     /* encoding */);
+
+  // The enc parameter of htmlCreatePushParserCtxt is deprecated and ignored
+  // in libxml2 >= 2.12. Use xmlSwitchEncoding() to explicitly set the
+  // encoding on the parser context. This is backward-compatible with older
+  // libxml2 versions where it is a harmless no-op.
+  if (self->ctxt && charEncoding != XML_CHAR_ENCODING_NONE) {
+    xmlSwitchEncoding((xmlParserCtxtPtr)self->ctxt, charEncoding);
+  }
+
   self->doc = NULL;
 }
 - (void)tearDownParser {


### PR DESCRIPTION
The enc parameter of htmlCreatePushParserCtxt() was deprecated and
is ignored in libxml2 >= 2.12.0. As a result, the HTML push parser defaults 
to ISO-8859-1 encoding regardless of the value passed, causing UTF-8 multibyte 
characters to be misinterpreted as Latin-1.

This breaks SOGo on systems with libxml2 >= 2.12 (e.g., RHEL 10):
- Viewing HTML emails with non-ASCII characters shows garbled text
- Plain text alternative parts of sent emails are double-encoded

Fix by calling xmlSwitchEncoding() after creating the push parser
context. This is the documented replacement for the deprecated enc
parameter per the libxml2 2.12.0 NEWS:

 "Calling xmlSwitchEncoding from client code is now fully supported,
  for example to override the encoding for the push parser."

The fix is backward-compatible with libxml2 2.9.x where it is a
harmless no-op since the encoding was already set via the enc
parameter.